### PR TITLE
Improve the re-broadcasting mechanism

### DIFF
--- a/crdt_test.go
+++ b/crdt_test.go
@@ -142,7 +142,6 @@ func (mb *mockBroadcaster) Next() ([]byte, error) {
 	case <-mb.ctx.Done():
 		return nil, ErrNoMoreBroadcast
 	}
-	return nil, nil
 }
 
 type mockDAGSync struct {

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
 	github.com/pkg/errors v0.8.1
 )
+
+go 1.13


### PR DESCRIPTION
Instead of skipping re-broadcasting whenever some new head has been
received in the interval, this will remember the CIDs received
during the re-broadcast interval and proceed to broadcast only
those that have not been seen during that interval.

This avoids a situation where a peer with new heads does
not rebroadcast them because the peers with old heads are rebroadcasting
the old ones.