### PR TITLE
Fix for duplicate Rmv delta set elements

### DIFF
--- a/set.go
+++ b/set.go
@@ -90,10 +90,19 @@ func (s *set) Rmv(key string) (*pb.Delta, error) {
 		}
 
 		id := strings.TrimPrefix(r.Key, prefix.String())
-		delta.Tombstones = append(delta.Tombstones, &pb.Element{
-			Key: key,
-			Id:  id,
-		})
+
+		// check if its already tombed, which case don't add it to the Rmv delta set
+		deleted, err := s.inTombsKeyID(key, id)
+		if err != nil {
+			return delta, err
+		}
+
+		if !deleted {
+			delta.Tombstones = append(delta.Tombstones, &pb.Element{
+				Key: key,
+				Id:  id,
+			})
+		}
 	}
 	return delta, nil
 }


### PR DESCRIPTION
Basic fix for #38.

Only needed a couple of lines changed. Just does a quick check to see if the results from the Query of all tags is already tombed, then don't add it to the set.

There might be a possible optimization where we only query for non-tombed elements with a single Query, but for now, this is sufficient.