### PR TITLE
Make Delete not return ErrNotFound for a missing key, per Datastore spec

### DIFF
--- a/crdt.go
+++ b/crdt.go
@@ -206,7 +206,7 @@ type dagJob struct {
 // the given prefix, but note that if other replicas are modifying the
 // datastore, the prefixes that will need syncing are not only those modified
 // by the local replica. Therefore the user should consider calling Sync("/"),
-// with an empty prefix, in that case, or use a synchronouse underlying
+// with an empty prefix, in that case, or use a synchronous underlying
 // datastore that persists things directly on write.
 //
 // The CRDT-Datastore should call Close() before the given store is closed.
@@ -358,7 +358,7 @@ func (store *Datastore) decodeBroadcast(data []byte) ([]cid.Cid, error) {
 		return nil, err
 	}
 
-	// Compatibility: before we were publishing CIDs direclty
+	// Compatibility: before we were publishing CIDs directly
 	msgReflect := bcastData.ProtoReflect()
 	if len(msgReflect.GetUnknown()) > 0 {
 		// Backwards compatibility
@@ -463,7 +463,7 @@ func (store *Datastore) handleBlock(c cid.Cid) error {
 	return nil
 }
 
-// dagWorker shouold run in its own gorountine. Workers are launched during
+// dagWorker should run in its own goroutine. Workers are launched during
 // initialization in New().
 func (store *Datastore) dagWorker() {
 	for job := range store.jobQueue {
@@ -495,7 +495,7 @@ func (store *Datastore) dagWorker() {
 	}
 }
 
-// sendNewJobs calls getDeltas (GetMany) on the crdtDAGService with the given
+// sendNewJobs calls getDeltas (GetMany) on the crdtNodeGetter with the given
 // children and sends each response to the workers. It will block until all
 // jobs have been queued.
 func (store *Datastore) sendNewJobs(session *sync.WaitGroup, ng *crdtNodeGetter, root cid.Cid, rootPrio uint64, children []cid.Cid) {
@@ -673,7 +673,7 @@ func (store *Datastore) Delete(key ds.Key) error {
 	}
 
 	if len(delta.Tombstones) == 0 {
-		return ds.ErrNotFound
+		return nil
 	}
 	return store.publish(delta)
 }
@@ -701,7 +701,7 @@ func (store *Datastore) Sync(prefix ds.Key) error {
 	// - each element has a datastore entry /setNamespace/elemsNamespace/<key>/<block_id>
 	// - each tomb has a datastore entry /setNamespace/tombsNamespace/<key>/<block_id>
 	// - each value has a datastore entry /setNamespace/keysNamespace/<key>/valueSuffix
-	// - each value has an additional priotity entry /setNamespace/keysNamespace/<key>/prioritySuffix
+	// - each value has an additional priority entry /setNamespace/keysNamespace/<key>/prioritySuffix
 	// - the last two are only written if the added entry has more priority than any the existing
 	// - For a value to not be lost, those entries should be fully synced.
 	// - In order to check if a value is in the set:

--- a/heads.go
+++ b/heads.go
@@ -56,11 +56,7 @@ func (hh *heads) write(store ds.Write, c cid.Cid, height uint64) error {
 }
 
 func (hh *heads) delete(store ds.Write, c cid.Cid) error {
-	err := store.Delete(hh.key(c))
-	if err == ds.ErrNotFound {
-		return nil
-	}
-	return err
+	return store.Delete(hh.key(c))
 }
 
 // IsHead returns if a given cid is among the current heads.

--- a/heads.go
+++ b/heads.go
@@ -56,7 +56,14 @@ func (hh *heads) write(store ds.Write, c cid.Cid, height uint64) error {
 }
 
 func (hh *heads) delete(store ds.Write, c cid.Cid) error {
-	return store.Delete(hh.key(c))
+	err := store.Delete(hh.key(c))
+	// The go-datastore API currently says Delete doesn't return
+	// ErrNotFound, but it used to say otherwise.  Leave this
+	// here to be safe.
+	if err == ds.ErrNotFound {
+		return nil
+	}
+	return err
 }
 
 // IsHead returns if a given cid is among the current heads.

--- a/set.go
+++ b/set.go
@@ -117,7 +117,7 @@ func (s *set) Rmv(key string) (*pb.Delta, error) {
 // Element retrieves the value of an element from the CRDT set.
 func (s *set) Element(key string) ([]byte, error) {
 	// We can only GET an element if it's part of the Set (in
-	// "elemements" and not in "tombstones").
+	// "elements" and not in "tombstones").
 
 	// As an optimization:
 	// * If the key has a value in the store it means:
@@ -402,7 +402,7 @@ func (s *set) setValue(writeStore ds.Write, key, id string, value []byte, prio u
 
 // putElems adds items to the "elems" set. It will also set current
 // values and priorities for each element. This needs to run in a lock,
-// as otherwise races may occurr when reading/writing the priorities, resulting
+// as otherwise races may occur when reading/writing the priorities, resulting
 // in bad behaviours.
 //
 // Technically the lock should only affect the keys that are being written,
@@ -519,7 +519,7 @@ func (s *set) inTombsKeyID(key, id string) (bool, error) {
 
 // currently unused
 // // inSet returns if the given cid/block is in elems and not in tombs (and
-// // thus, it is an elemement of the set).
+// // thus, it is an element of the set).
 // func (s *set) inSetKeyID(key, id string) (bool, error) {
 // 	inTombs, err := s.inTombsKeyID(key, id)
 // 	if err != nil {


### PR DESCRIPTION
Fixes #62.  (Also a few typos.)