### PR TITLE
Handle some errors that were ignored

### DIFF
--- a/crdt.go
+++ b/crdt.go
@@ -425,7 +425,10 @@ func (store *Datastore) rebroadcastHeads() {
 	store.seenHeadsMux.RUnlock()
 
 	// Send them out
-	store.broadcast(headsToBroadcast)
+	err = store.broadcast(headsToBroadcast)
+	if err != nil {
+		store.logger.Warn("broadcast failed: %v", err)
+	}
 
 	// Reset the map
 	store.seenHeadsMux.Lock()
@@ -608,7 +611,10 @@ func (store *Datastore) processNode(ng *crdtNodeGetter, root cid.Cid, rootPrio u
 		if known {
 			// we reached a non-head node in the known tree.
 			// This means our root block is a new head.
-			store.heads.Add(root, rootPrio)
+			err = store.heads.Add(root, rootPrio)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error adding head %s", root)
+			}
 			continue
 		}
 

--- a/crdt.go
+++ b/crdt.go
@@ -613,7 +613,8 @@ func (store *Datastore) processNode(ng *crdtNodeGetter, root cid.Cid, rootPrio u
 			// This means our root block is a new head.
 			err = store.heads.Add(root, rootPrio)
 			if err != nil {
-				return nil, errors.Wrapf(err, "error adding head %s", root)
+				// Don't let this failure prevent us from processing the other links.
+				store.logger.Error(errors.Wrapf(err, "error adding head %s", root))
 			}
 			continue
 		}

--- a/set.go
+++ b/set.go
@@ -82,11 +82,7 @@ func (s *set) Rmv(key string) (*pb.Delta, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		if results != nil {
-			_ = results.Close()
-		}
-	}()
+	defer results.Close()
 
 	for r := range results.Next() {
 		if r.Error != nil {
@@ -114,10 +110,6 @@ func (s *set) Rmv(key string) (*pb.Delta, error) {
 				Id:  id,
 			})
 		}
-	}
-	err = results.Close()
-	if err != nil {
-		return nil, err
 	}
 	return delta, nil
 }


### PR DESCRIPTION
Also adhere to the nil,err or value,nil return convention.

I only changed one of the `results.Close()` ignored errors, not sure if that's actually something we should care about or not.