### PR TITLE
Tests: disable TestDatastoreSuite when race detector enabled

### DIFF
--- a/crdt_norace_test.go
+++ b/crdt_norace_test.go
@@ -1,0 +1,41 @@
+// +build !race
+
+package crdt
+
+import (
+	"testing"
+	"time"
+
+	query "github.com/ipfs/go-datastore/query"
+	dstest "github.com/ipfs/go-datastore/test"
+)
+
+func TestDatastoreSuite(t *testing.T) {
+	numReplicasOld := numReplicas
+	numReplicas = 1
+	defer func() {
+		numReplicas = numReplicasOld
+	}()
+	opts := DefaultOptions()
+	opts.MaxBatchDeltaSize = 200 * 1024 * 1024 // 200 MB
+	replicas, closeReplicas := makeReplicas(t, opts)
+	defer closeReplicas()
+	dstest.SubtestAll(t, replicas[0])
+	time.Sleep(time.Second)
+
+	for _, r := range replicas {
+		q := query.Query{KeysOnly: true}
+		results, err := r.Query(q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer results.Close()
+		rest, err := results.Rest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rest) != 0 {
+			t.Error("all elements in the suite should be gone")
+		}
+	}
+}

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -330,36 +330,6 @@ func TestCRDT(t *testing.T) {
 	}
 }
 
-func TestDatastoreSuite(t *testing.T) {
-	numReplicasOld := numReplicas
-	numReplicas = 1
-	defer func() {
-		numReplicas = numReplicasOld
-	}()
-	opts := DefaultOptions()
-	opts.MaxBatchDeltaSize = 200 * 1024 * 1024 // 200 MB
-	replicas, closeReplicas := makeReplicas(t, opts)
-	defer closeReplicas()
-	dstest.SubtestAll(t, replicas[0])
-	time.Sleep(time.Second)
-
-	for _, r := range replicas {
-		q := query.Query{KeysOnly: true}
-		results, err := r.Query(q)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer results.Close()
-		rest, err := results.Rest()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(rest) != 0 {
-			t.Error("all elements in the suite should be gone")
-		}
-	}
-}
-
 func TestCRDTReplication(t *testing.T) {
 	nItems := 50
 


### PR DESCRIPTION
Move the TestDatastoreSuite to a file with // +build !race so that it does not
run when the race detector is enabled.