### PR TITLE
extend timeout for CI tests

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,0 +1,9 @@
+name: extend-tests-timeout
+description: add -timeout 20m flag to GOFLAGS to extend timeout for tests
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extend timeout for tests
+      shell: bash
+      run: echo "GOFLAGS=$GOFLAGS -timeout=20m" >> $GITHUB_ENV


### PR DESCRIPTION
I believe the tests in https://github.com/ipfs/go-ds-crdt/pull/112 just about miss the 10m mark and that by extending the timeout to 20m we will be able to get more consistent runs.

I have tested it in CI on my forked repo: https://github.com/galargh/go-ds-crdt/actions/runs/1467239280 (the one failure on mac was cause by network issues).

By merging this PR we can restore the common, integrated CI and retire the custom action (note that the custom testing action was also prone to the timeout issue in some runs - it's just less noticeable because we're testing on fewer platforms there).