### PR TITLE
Performance improvement for Query calls

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,4 +43,4 @@ jobs:
         go-version: 1.15
 
     - name: Test
-      run: go test -v -run "TestDatastoreSuite" .
+      run: go test -timeout 30m -v -run "TestDatastoreSuite" .

--- a/crdt.go
+++ b/crdt.go
@@ -246,13 +246,17 @@ func New(
 		opts.DeleteHook(dsk)
 	}
 
-	set := newCRDTSet(store, fullSetNs, setPutHook, setDeleteHook)
+	ctx, cancel := context.WithCancel(context.Background())
+	set, err := newCRDTSet(ctx, store, fullSetNs, opts.Logger, setPutHook, setDeleteHook)
+	if err != nil {
+		cancel()
+		return nil, errors.Wrap(err, "error setting up crdt set")
+	}
 	heads, err := newHeads(store, fullHeadsNs, opts.Logger)
 	if err != nil {
+		cancel()
 		return nil, errors.Wrap(err, "error building heads")
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
 
 	dstore := &Datastore{
 		ctx:               ctx,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ipfs/go-ds-crdt
 require (
 	github.com/dgraph-io/badger v1.6.2
 	github.com/golang/protobuf v1.5.2
+	github.com/ipfs/bbloom v0.0.4
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.0
 	github.com/ipfs/go-ds-badger v0.3.0


### PR DESCRIPTION
Fixes #109.

When working with millions of keys, and trying to list them all, each key
would trigger a subquery to verify that at least one of the CRDT-blocks in
which the key was added as not been tombstoned (if all were tombstoned, then
the key is considered removed).

Benchmarking suggests this subquery to the underlying datastore is very
expensive to make for each element and skipping it results in large
improvements.

We cannot avoid this subquery whenever an element has been deleted at some
point (and potentially re-added), but we can skip it when that has not
happened at all. In our usage of go-ds-crdt in cluster, it is quite uncommon
to delete items, and most items would have never been delete.

We can determine which items have ever been deleted by checking all the keys
in the tombstone namespaces. This allows us to initialize and introduce a bloom
filter which can tell us which items have never been deleted. Thus, we can
skip tombstone-checking altogether.

With in-mem benchmarking, this reduces the time to list items that have never
been deleted from 2211563 ns/item to 3912 ns/op. That sounds very very good
(1000x improvement), and I hope that it translates to badger/leveldb well
enough.