### PR TITLE
broadcast: randomize rebroadcast interval by 30%

### DIFF
--- a/crdt_test.go
+++ b/crdt_test.go
@@ -896,3 +896,17 @@ func BenchmarkQueryElements(b *testing.B) {
 	}
 	b.Log(totalSize)
 }
+
+func TestRandomizeInterval(t *testing.T) {
+	prevR := 100 * time.Second
+	for i := 0; i < 1000; i++ {
+		r := randomizeInterval(100 * time.Second)
+		if r < 70*time.Second || r > 130*time.Second {
+			t.Error("r was ", r)
+		}
+		if prevR == r {
+			t.Log("r and prevR were equal")
+		}
+		prevR = r
+	}
+}


### PR DESCRIPTION
This ensures that peers that have been started at the same time are not
rebroadcasting at the same time. It also ensures that a peer is not always the
same one rebroadcasting because others backoff after seeing it.