### PR TITLE
Fix #238: Non converging operations with unordered deletes. Migration to fix existing datastores.

### DIFF
--- a/crdt_test.go
+++ b/crdt_test.go
@@ -2,6 +2,7 @@ package crdt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -97,7 +98,7 @@ type mockBroadcaster struct {
 	ctx      context.Context
 	chans    []chan []byte
 	myChan   chan []byte
-	dropProb int // probability of dropping a message instead of receiving it
+	dropProb *atomic.Int64 // probability of dropping a message instead of receiving it
 	t        testing.TB
 }
 
@@ -105,13 +106,14 @@ func newBroadcasters(t testing.TB, n int) ([]*mockBroadcaster, context.CancelFun
 	ctx, cancel := context.WithCancel(context.Background())
 	broadcasters := make([]*mockBroadcaster, n)
 	chans := make([]chan []byte, n)
+	dropP := &atomic.Int64{}
 	for i := range chans {
 		chans[i] = make(chan []byte, 300)
 		broadcasters[i] = &mockBroadcaster{
 			ctx:      ctx,
 			chans:    chans,
 			myChan:   chans[i],
-			dropProb: 0,
+			dropProb: dropP,
 			t:        t,
 		}
 	}
@@ -124,8 +126,8 @@ func (mb *mockBroadcaster) Broadcast(data []byte) error {
 	randg := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for i, ch := range mb.chans {
-		n := randg.Intn(100)
-		if n < mb.dropProb {
+		n := randg.Int63n(100)
+		if n < mb.dropProb.Load() {
 			continue
 		}
 		wg.Add(1)
@@ -235,7 +237,7 @@ func makeNReplicas(t testing.TB, n int, opts *Options) ([]*Datastore, func()) {
 			name: fmt.Sprintf("r#%d: ", i),
 			l:    DefaultOptions().Logger,
 		}
-		replicaOpts[i].RebroadcastInterval = time.Second * 10
+		replicaOpts[i].RebroadcastInterval = time.Second * 5
 		replicaOpts[i].NumWorkers = 5
 		replicaOpts[i].DAGSyncerTimeout = time.Second
 	}
@@ -489,7 +491,7 @@ func TestCRDTCatchUp(t *testing.T) {
 
 	r := replicas[len(replicas)-1]
 	br := r.broadcaster.(*mockBroadcaster)
-	br.dropProb = 101
+	br.dropProb.Store(101)
 
 	// this items will not get to anyone
 	for i := 0; i < nItems; i++ {
@@ -501,7 +503,7 @@ func TestCRDTCatchUp(t *testing.T) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	br.dropProb = 0
+	br.dropProb.Store(0)
 
 	// this message will get to everyone
 	err := r.Put(ctx, ds.RandomKey(), nil)
@@ -817,56 +819,6 @@ func TestCRDTBroadcastBackwardsCompat(t *testing.T) {
 	}
 }
 
-// There is no easy way to see if the bloom filter is doing its job without
-// wiring some sort of metric or benchmarking. Instead, this just hits the
-// 3 places relevant to bloom filter:
-// * When adding a tomb
-// * When checking if something is tombstoned
-// * When priming the filter
-//
-// The main thing is to manually verify (via printlns) that the bloom filter
-// is used with the expected key everywhere: i.e. "/mykey" and not
-// "mykey". "/something/else" and not "/something". Protip: it has been
-// verified and it does that.
-func TestBloomingTombstones(t *testing.T) {
-	ctx := context.Background()
-	replicas, closeReplicas := makeNReplicas(t, 1, nil)
-	defer closeReplicas()
-
-	k := ds.NewKey("hola/adios/")
-	err := replicas[0].Put(ctx, k, []byte("bytes"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = replicas[0].Delete(ctx, k)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = replicas[0].Put(ctx, k, []byte("bytes"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	q := query.Query{
-		KeysOnly: false,
-	}
-	results, err := replicas[0].Query(ctx, q)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer results.Close()
-
-	for r := range results.Next() {
-		if r.Error != nil {
-			t.Error(r.Error)
-		}
-	}
-
-	replicas[0].set.primeBloomFilter(ctx)
-}
-
 func BenchmarkQueryElements(b *testing.B) {
 	ctx := context.Background()
 	replicas, closeReplicas := makeNReplicas(b, 1, nil)
@@ -912,5 +864,146 @@ func TestRandomizeInterval(t *testing.T) {
 			t.Log("r and prevR were equal")
 		}
 		prevR = r
+	}
+}
+
+func TestCRDTPutPutDelete(t *testing.T) {
+	replicas, closeReplicas := makeNReplicas(t, 2, nil)
+	defer closeReplicas()
+
+	ctx := context.Background()
+
+	br0 := replicas[0].broadcaster.(*mockBroadcaster)
+	br0.dropProb.Store(101)
+
+	br1 := replicas[1].broadcaster.(*mockBroadcaster)
+	br1.dropProb.Store(101)
+
+	k := ds.NewKey("k1")
+
+	// r0 - put put delete
+	err := replicas[0].Put(ctx, k, []byte("r0-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = replicas[0].Put(ctx, k, []byte("r0-2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = replicas[0].Delete(ctx, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// r1 - put
+	err = replicas[1].Put(ctx, k, []byte("r1-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	br0.dropProb.Store(0)
+	br1.dropProb.Store(0)
+
+	time.Sleep(15 * time.Second)
+
+	r0Res, err := replicas[0].Get(ctx, ds.NewKey("k1"))
+	if err != nil {
+		if !errors.Is(err, ds.ErrNotFound) {
+			t.Fatal(err)
+		}
+	}
+
+	r1Res, err := replicas[1].Get(ctx, ds.NewKey("k1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeReplicas()
+
+	if string(r0Res) != string(r1Res) {
+		fmt.Printf("r0Res: %s\nr1Res: %s\n", string(r0Res), string(r1Res))
+		t.Log("r0 dag")
+		replicas[0].PrintDAG()
+
+		t.Log("r1 dag")
+		replicas[1].PrintDAG()
+
+		t.Fatal("r0 and r1 should have the same value")
+	}
+}
+
+func TestMigration0to1(t *testing.T) {
+	replicas, closeReplicas := makeNReplicas(t, 1, nil)
+	defer closeReplicas()
+	replica := replicas[0]
+	ctx := context.Background()
+
+	nItems := 200
+	var keys []ds.Key
+	// Add nItems
+	for i := 0; i < nItems; i++ {
+		k := ds.RandomKey()
+		keys = append(keys, k)
+		v := []byte(fmt.Sprintf("%d", i))
+		err := replica.Put(ctx, k, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+	}
+
+	// Overwrite n/2 items 5 times to have multiple tombstones per key
+	// later...
+	for j := 0; j < 5; j++ {
+		for i := 0; i < nItems/2; i++ {
+			v := []byte(fmt.Sprintf("%d", i))
+			err := replica.Put(ctx, keys[i], v)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// delete keys
+	for i := 0; i < nItems/2; i++ {
+		err := replica.Delete(ctx, keys[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// And write them again
+	for i := 0; i < nItems/2; i++ {
+		err := replica.Put(ctx, keys[i], []byte("final value"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// And now we manually put the wrong value
+	for i := 0; i < nItems/2; i++ {
+		valueK := replica.set.valueKey(keys[i].String())
+		err := replica.set.store.Put(ctx, valueK, []byte("wrong value"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = replica.set.setPriority(ctx, replica.set.store, keys[i].String(), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := replica.migrate0to1(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < nItems/2; i++ {
+		v, err := replica.Get(ctx, keys[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(v) != "final value" {
+			t.Fatalf("value for elem %d should be final value: %s", i, string(v))
+		}
 	}
 }

--- a/migrations.go
+++ b/migrations.go
@@ -1,0 +1,158 @@
+package crdt
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	ds "github.com/ipfs/go-datastore"
+	query "github.com/ipfs/go-datastore/query"
+	"github.com/pkg/errors"
+)
+
+// Use this to detect if we need to run migrations.
+var version uint64 = 1
+
+func (store *Datastore) versionKey() ds.Key {
+	return store.namespace.ChildString(versionKey)
+}
+
+func (store *Datastore) getVersion(ctx context.Context) (uint64, error) {
+	versionK := store.versionKey()
+	data, err := store.store.Get(ctx, versionK)
+	if err != nil {
+		if err == ds.ErrNotFound {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	v, n := binary.Uvarint(data)
+	if n <= 0 {
+		return v, errors.New("error decoding version")
+	}
+	return v - 1, nil
+}
+
+func (store *Datastore) setVersion(ctx context.Context, v uint64) error {
+	versionK := store.versionKey()
+	buf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(buf, v+1)
+	if n == 0 {
+		return errors.New("error encoding version")
+	}
+
+	return store.store.Put(ctx, versionK, buf[0:n])
+}
+
+func (store *Datastore) applyMigrations(ctx context.Context) error {
+	v, err := store.getVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch v {
+	case 0: // need to migrate
+		err := store.migrate0to1(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = store.setVersion(ctx, 1)
+		if err != nil {
+			return err
+		}
+		fallthrough
+
+	case version:
+		store.logger.Infof("CRDT database format v%d")
+		return nil
+	}
+	return nil
+}
+
+// migrate0to1 re-sets all the values and priorities of previously tombstoned
+// elements to deal with the aftermath of
+// https://github.com/ipfs/go-ds-crdt/issues/238. This bug caused that the
+// values/priorities of certain elements was wrong depending on tombstone
+// arrival order.
+func (store *Datastore) migrate0to1(ctx context.Context) error {
+	// 1. Find keys for which we have tombstones
+	// 2. Loop them
+	// 3. Find/set best value for them
+
+	s := store.set
+	tombsPrefix := s.keyPrefix(tombsNs) // /ns/tombs
+	q := query.Query{
+		Prefix:   tombsPrefix.String(),
+		KeysOnly: true,
+	}
+
+	var rStore = store.store
+	var wStore ds.Write = store.store
+	var err error
+	batchingDs, batching := wStore.(ds.Batching)
+	if batching {
+		wStore, err = batchingDs.Batch(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	results, err := rStore.Query(ctx, q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+
+	// Results are not going to be ordered per key (I tested). Therefore,
+	// we can keep a list of keys in memory to avoid findingBestValue for
+	// every tombstone block entry, or we can repeat the operation every
+	// time there is a tombstone for the same key.  Given this is a one
+	// time operation that only affects tombstoned keys, we opt to
+	// de-duplicate.
+
+	var total int
+	doneKeys := make(map[string]struct{})
+	for r := range results.Next() {
+		if r.Error != nil {
+			return r.Error
+		}
+
+		// Switch from /ns/tombs/key/block to /key
+		dskey := ds.NewKey(
+			strings.TrimPrefix(r.Key, tombsPrefix.String()))
+		// Switch from /key/block to /key
+		key := dskey.Parent().String()
+		if _, ok := doneKeys[key]; ok {
+			continue
+		}
+		doneKeys[key] = struct{}{}
+
+		valueK := s.valueKey(key)
+		v, p, err := s.findBestValue(ctx, key, nil)
+		if err != nil {
+			return fmt.Errorf("error finding best value for %s: %w", key, err)
+		}
+
+		if v == nil {
+			wStore.Delete(ctx, valueK)
+			wStore.Delete(ctx, s.priorityKey(key))
+		} else {
+			wStore.Put(ctx, valueK, v)
+			s.setPriority(ctx, wStore, key, p)
+		}
+		total++
+	}
+
+	if batching {
+		err := wStore.(ds.Batch).Commit(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.logger.Infof("Migration v0 to v1 finished (%d elements affected)", total)
+	return nil
+}

--- a/set.go
+++ b/set.go
@@ -7,10 +7,11 @@ import (
 	"errors"
 	"strings"
 	"sync"
-	"time"
 
-	bloom "github.com/ipfs/bbloom"
+	dshelp "github.com/ipfs/boxo/datastore/dshelp"
+	cid "github.com/ipfs/go-cid"
 	pb "github.com/ipfs/go-ds-crdt/pb"
+	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
 	goprocess "github.com/jbenet/goprocess"
 	multierr "go.uber.org/multierr"
@@ -35,6 +36,7 @@ var (
 // sorting their unique IDs alphabetically.
 type set struct {
 	store      ds.Datastore
+	dagService ipld.DAGService
 	namespace  ds.Key
 	putHook    func(key string, v []byte)
 	deleteHook func(key string)
@@ -43,84 +45,28 @@ type set struct {
 	// Avoid merging two things at the same time since
 	// we read-write value-priorities in a non-atomic way.
 	putElemsMux sync.Mutex
-
-	tombstonesBloom *bloom.Bloom
 }
-
-// Tombstones bloom filter options.
-// We have optimized the defaults for speed:
-// - commit 30 MiB of memory to the filter
-// - only hash twice
-// - False positive probabily is 1 in 10000 when working with 1M items in the filter.
-// See https://hur.st/bloomfilter/?n=&p=0.0001&m=30MiB&k=2
-var (
-	TombstonesBloomFilterSize   float64 = 30 * 1024 * 1024 * 8 // 30 MiB
-	TombstonesBloomFilterHashes float64 = 2
-)
 
 func newCRDTSet(
 	ctx context.Context,
 	d ds.Datastore,
 	namespace ds.Key,
+	dagService ipld.DAGService,
 	logger logging.StandardLogger,
 	putHook func(key string, v []byte),
 	deleteHook func(key string),
 ) (*set, error) {
 
-	blm, err := bloom.New(
-		float64(TombstonesBloomFilterSize),
-		float64(TombstonesBloomFilterHashes),
-	)
-	if err != nil {
-		return nil, err
-	}
-
 	set := &set{
-		namespace:       namespace,
-		store:           d,
-		logger:          logger,
-		putHook:         putHook,
-		deleteHook:      deleteHook,
-		tombstonesBloom: blm,
+		namespace:  namespace,
+		store:      d,
+		dagService: dagService,
+		logger:     logger,
+		putHook:    putHook,
+		deleteHook: deleteHook,
 	}
 
-	return set, set.primeBloomFilter(ctx)
-}
-
-// We need to add all <key/block> keys in tombstones to the filter.
-func (s *set) primeBloomFilter(ctx context.Context) error {
-	tombsPrefix := s.keyPrefix(tombsNs) // /ns/tombs
-	q := query.Query{
-		Prefix:   tombsPrefix.String(),
-		KeysOnly: true,
-	}
-
-	t := time.Now()
-	nTombs := 0
-
-	results, err := s.store.Query(ctx, q)
-	if err != nil {
-		return err
-	}
-	defer results.Close()
-
-	for r := range results.Next() {
-		if r.Error != nil {
-			return r.Error
-		}
-
-		// Switch from /ns/tombs/key/block to /key/block
-		key := ds.NewKey(
-			strings.TrimPrefix(r.Key, tombsPrefix.String()))
-		// Switch from /key/block to key
-		key = key.Parent()
-		// fmt.Println("Bloom filter priming with:", key)
-		// put the key in the bloom cache
-		s.tombstonesBloom.Add(key.Bytes())
-		nTombs++
-	}
-	s.logger.Infof("Tombstones have bloomed: %d tombs. Took: %s", nTombs, time.Since(t))
-	return nil
+	return set, nil
 }
 
 // Add returns a new delta-set adding the given key/value.
@@ -188,34 +134,15 @@ func (s *set) Element(ctx context.Context, key string) ([]byte, error) {
 	// We can only GET an element if it's part of the Set (in
 	// "elements" and not in "tombstones").
 
-	// As an optimization:
-	// * If the key has a value in the store it means:
-	//   -> It occurs at least once in "elems"
-	//   -> It may or not be tombstoned
-	// * If the key does not have a value in the store:
-	//   -> It was either never added
+	// * If the key has a value in the store it means that it has been
+	//   written and is alive. putTombs will delete the value if all elems
+	//   are tombstoned, or leave the best one.
+
 	valueK := s.valueKey(key)
 	value, err := s.store.Get(ctx, valueK)
 	if err != nil { // not found is fine, we just return it
 		return value, err
 	}
-
-	// We have an existing element. Check if tombstoned.
-	inSet, err := s.checkNotTombstoned(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-
-	if !inSet {
-		// attempt to remove so next time we do not have to do this
-		// lookup.
-		// In concurrency, this may delete a key that was just written
-		// and should not be deleted.
-		// s.store.Delete(valueK)
-
-		return nil, ds.ErrNotFound
-	}
-	// otherwise return the value
 	return value, nil
 }
 
@@ -326,15 +253,11 @@ func (s *set) Elements(ctx context.Context, q query.Query) (query.Results, error
 			entry.Value = r.Value
 			entry.Size = r.Size
 			entry.Expiration = r.Expiration
-			has, err := s.checkNotTombstoned(ctx, key)
-			if err != nil {
-				sendResult(b, p, query.Result{Error: err})
-				return
-			}
 
-			if !has {
-				continue
-			}
+			// The fact that /v is set means it is not tombstoned,
+			// as tombstoning removes /v and /p or sets them to
+			// the best value.
+
 			if q.KeysOnly {
 				entry.Size = -1
 				entry.Value = nil
@@ -351,73 +274,10 @@ func (s *set) Elements(ctx context.Context, q query.Query) (query.Results, error
 // InSet returns true if the key belongs to one of the elements in the "elems"
 // set, and this element is not tombstoned.
 func (s *set) InSet(ctx context.Context, key string) (bool, error) {
-	// Optimization: if we do not have a value
-	// this key was never added.
+	// If we do not have a value this key was never added or it was fully
+	// tombstoned.
 	valueK := s.valueKey(key)
-	if ok, err := s.store.Has(ctx, valueK); !ok {
-		return false, err
-	}
-
-	// Otherwise, do the long check.
-	return s.checkNotTombstoned(ctx, key)
-}
-
-// Returns true when we have a key/block combination in the
-// elements set that has not been tombstoned.
-//
-// Warning: In order to do a quick bloomfilter check, this assumes the key is
-// in elems already. Any code calling this function already has verified
-// that there is a value-key entry for the key, thus there must necessarily
-// be a non-empty set of key/block in elems.
-//
-// Put otherwise: this code will misbehave when called directly to check if an
-// element exists. See Element()/InSet() etc..
-func (s *set) checkNotTombstoned(ctx context.Context, key string) (bool, error) {
-	// Bloom filter check: has this key been potentially tombstoned?
-
-	// fmt.Println("Bloom filter check:", key)
-	if !s.tombstonesBloom.HasTS([]byte(key)) {
-		return true, nil
-	}
-
-	// /namespace/elems/<key>
-	prefix := s.elemsPrefix(key)
-	q := query.Query{
-		Prefix:   prefix.String(),
-		KeysOnly: true,
-	}
-
-	results, err := s.store.Query(ctx, q)
-	if err != nil {
-		return false, err
-	}
-	defer results.Close()
-
-	// range all the /namespace/elems/<key>/<block_cid>.
-	for r := range results.Next() {
-		if r.Error != nil {
-			return false, err
-		}
-
-		id := strings.TrimPrefix(r.Key, prefix.String())
-		if !ds.RawKey(id).IsTopLevel() {
-			// our prefix matches blocks from other keys i.e. our
-			// prefix is "hello" and we have a different key like
-			// "hello/bye" so we have a block id like
-			// "bye/<block>". If we got the right key, then the id
-			// should be the block id only.
-			continue
-		}
-		// if not tombstoned, we have it
-		inTomb, err := s.inTombsKeyID(ctx, key, id)
-		if err != nil {
-			return false, err
-		}
-		if !inTomb {
-			return true, nil
-		}
-	}
-	return false, nil
+	return s.store.Has(ctx, valueK)
 }
 
 // /namespace/<key>
@@ -476,8 +336,7 @@ func (s *set) setPriority(ctx context.Context, writeStore ds.Write, key string, 
 // sets a value if priority is higher. When equal, it sets if the
 // value is lexicographically higher than the current value.
 func (s *set) setValue(ctx context.Context, writeStore ds.Write, key, id string, value []byte, prio uint64) error {
-	// If this key was tombstoned already, do not store/update the value
-	// at all.
+	// If this key was tombstoned already, do not store/update the value.
 	deleted, err := s.inTombsKeyID(ctx, key, id)
 	if err != nil || deleted {
 		return err
@@ -516,6 +375,106 @@ func (s *set) setValue(ctx context.Context, writeStore ds.Write, key, id string,
 	// trigger add hook
 	s.putHook(key, value)
 	return nil
+}
+
+// findBestValue looks for all entries for the given key, figures out their
+// priority from their delta (skipping the blocks by the given pendingTombIDs)
+// and returns the value with the highest priority that is not tombstoned nor
+// about to be tombstoned.
+func (s *set) findBestValue(ctx context.Context, key string, pendingTombIDs []string) ([]byte, uint64, error) {
+	// /namespace/elems/<key>
+	prefix := s.elemsPrefix(key)
+	q := query.Query{
+		Prefix:   prefix.String(),
+		KeysOnly: true,
+	}
+
+	results, err := s.store.Query(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer results.Close()
+
+	var bestValue []byte
+	var bestPriority uint64
+	var deltaCid cid.Cid
+	ng := crdtNodeGetter{NodeGetter: s.dagService}
+
+	// range all the /namespace/elems/<key>/<block_cid>.
+NEXT:
+	for r := range results.Next() {
+		if r.Error != nil {
+			return nil, 0, err
+		}
+
+		id := strings.TrimPrefix(r.Key, prefix.String())
+		if !ds.RawKey(id).IsTopLevel() {
+			// our prefix matches blocks from other keys i.e. our
+			// prefix is "hello" and we have a different key like
+			// "hello/bye" so we have a block id like
+			// "bye/<block>". If we got the right key, then the id
+			// should be the block id only.
+			continue
+		}
+		// if block is one of the pending tombIDs, continue
+		for _, tombID := range pendingTombIDs {
+			if tombID == id {
+				continue NEXT
+			}
+		}
+
+		// if tombstoned, continue
+		inTomb, err := s.inTombsKeyID(ctx, key, id)
+		if err != nil {
+			return nil, 0, err
+		}
+		if inTomb {
+			continue
+		}
+
+		// get the block
+		mhash, err := dshelp.DsKeyToMultihash(ds.NewKey(id))
+		if err != nil {
+			return nil, 0, err
+		}
+		deltaCid = cid.NewCidV1(cid.DagProtobuf, mhash)
+		_, delta, err := ng.GetDelta(ctx, deltaCid)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		// discard this delta.
+		if delta.Priority < bestPriority {
+			continue
+		}
+
+		// When equal priority, choose the greatest among values in
+		// the delta and current. When higher priority, choose the
+		// greatest only among those in the delta.
+		var greatestValueInDelta []byte
+		for _, elem := range delta.GetElements() {
+			if elem.GetKey() != key {
+				continue
+			}
+			v := elem.GetValue()
+			if bytes.Compare(greatestValueInDelta, v) < 0 {
+				greatestValueInDelta = v
+			}
+		}
+
+		if delta.Priority > bestPriority {
+			bestValue = greatestValueInDelta
+			bestPriority = delta.Priority
+			continue
+		}
+
+		// equal priority
+		if bytes.Compare(bestValue, greatestValueInDelta) < 0 {
+			bestValue = greatestValueInDelta
+		}
+	}
+
+	return bestValue, bestPriority, nil
 }
 
 // putElems adds items to the "elems" set. It will also set current
@@ -588,23 +547,35 @@ func (s *set) putTombs(ctx context.Context, tombs []*pb.Element) error {
 		}
 	}
 
-	deletedElems := make(map[string]struct{})
+	// key -> tombstonedBlockID. Carries the tombstoned blocks for each
+	// element in this delta.
+	deletedElems := make(map[string][]string)
+
 	for _, e := range tombs {
 		// /namespace/tombs/<key>/<id>
-		elemKey := e.GetKey()
-		k := s.tombsPrefix(elemKey).ChildString(e.GetId())
-		err := store.Put(ctx, k, nil)
+		key := e.GetKey()
+		id := e.GetId()
+		valueK := s.valueKey(key)
+		deletedElems[key] = append(deletedElems[key], id)
+
+		// Find best value for element that we are going to delete
+		v, p, err := s.findBestValue(ctx, key, deletedElems[key])
 		if err != nil {
 			return err
 		}
-		s.tombstonesBloom.AddTS([]byte(elemKey))
-		//fmt.Println("Bloom filter add:", elemKey)
-		// run delete hook only once for all
-		// versions of the same element tombstoned
-		// in this delta
-		if _, ok := deletedElems[elemKey]; !ok {
-			deletedElems[elemKey] = struct{}{}
-			s.deleteHook(elemKey)
+		if v == nil {
+			store.Delete(ctx, valueK)
+			store.Delete(ctx, s.priorityKey(key))
+		} else {
+			store.Put(ctx, valueK, v)
+			s.setPriority(ctx, store, key, p)
+		}
+
+		// Write tomb into store.
+		k := s.tombsPrefix(key).ChildString(id)
+		err = store.Put(ctx, k, nil)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -614,6 +585,14 @@ func (s *set) putTombs(ctx context.Context, tombs []*pb.Element) error {
 			return err
 		}
 	}
+
+	// run delete hook only once for all versions of the same element
+	// tombstoned in this delta. Note it may be that the element was not
+	// fully deleted and only a different value took its place.
+	for del := range deletedElems {
+		s.deleteHook(del)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This is made of two commits, one fixes the problem with the wrong values being set for elements that are partially tombstoned. The second adds a migration to fix potentially wrong values, but also to ensure that we return the right thing now that we don't check for tombstoning anymore on Get(). Fixes #238 .