### PR TITLE
Small fix in newBroadcasters test helper function

### DIFF
--- a/crdt_test.go
+++ b/crdt_test.go
@@ -98,7 +98,7 @@ type mockBroadcaster struct {
 	ctx      context.Context
 	chans    []chan []byte
 	myChan   chan []byte
-	dropProb *atomic.Int64 // probability of dropping a message instead of receiving it
+	dropProb *atomic.Int64 // probability of dropping a message instead of broadcasting it
 	t        testing.TB
 }
 
@@ -106,8 +106,8 @@ func newBroadcasters(t testing.TB, n int) ([]*mockBroadcaster, context.CancelFun
 	ctx, cancel := context.WithCancel(context.Background())
 	broadcasters := make([]*mockBroadcaster, n)
 	chans := make([]chan []byte, n)
-	dropP := &atomic.Int64{}
 	for i := range chans {
+		dropP := &atomic.Int64{}
 		chans[i] = make(chan []byte, 300)
 		broadcasters[i] = &mockBroadcaster{
 			ctx:      ctx,


### PR DESCRIPTION
The `newBroadcasters` test helper function in `crdt_test.go` reuses the same `dropProb` for all created broadcasters. This will not work correctly if we want to create a test that sets different drop probabilities for different replicas.

This PR fixes that function by creating a new `dropProb` for each broadcaster.

It also makes a minor fix to a related comment in the same file.