### PR TITLE
feat: add PurgeDAG to remove all state for a named DAG

### DIFF
--- a/crdt_test.go
+++ b/crdt_test.go
@@ -1417,8 +1417,7 @@ func makeNReplicasNoBcast(t testing.TB, n int, opts *Options) ([]*Datastore, fun
 	for i := range bcasts {
 		bcasts[i] = &nullBroadcaster{}
 	}
-	_, cancel := context.WithCancel(t.Context())
-	return makeNReplicasWithBroadcasters(t, n, opts, bcasts, cancel)
+	return makeNReplicasWithBroadcasters(t, n, opts, bcasts, func() {})
 }
 
 func TestPurgeDAG(t *testing.T) {
@@ -1494,7 +1493,7 @@ func TestPurgeDAG(t *testing.T) {
 
 	// Set entry for k1 (dag1 key) is gone.
 	_, err = replica.set.Element(ctx, k1.String())
-	if err != ds.ErrNotFound {
+	if !errors.Is(err, ds.ErrNotFound) {
 		t.Errorf("expected ErrNotFound for key1 after purge, got %v", err)
 	}
 
@@ -1566,7 +1565,7 @@ func TestPurgeDAGMixedKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The key should still exist with dag2's value.
+	// The key should still exist with dag1's value.
 	val, err := replica.set.Element(ctx, key)
 	if err != nil {
 		t.Fatalf("key should survive after purging dag2: %v", err)
@@ -1596,6 +1595,7 @@ func TestPurgeDAGCleanStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { replica.Close() })
 
 	mcrdt := MerkleCRDT{replica}
 

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -25,8 +25,10 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-var numReplicas = 15
-var debug = false
+var (
+	numReplicas = 15
+	debug       = false
+)
 
 const (
 	mapStore = iota
@@ -48,46 +50,57 @@ func (tl *testLogger) Debug(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Debug(args...)
 }
+
 func (tl *testLogger) Debugf(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Debugf("%s "+format, args...)
 }
+
 func (tl *testLogger) Error(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Error(args...)
 }
+
 func (tl *testLogger) Errorf(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Errorf("%s "+format, args...)
 }
+
 func (tl *testLogger) Fatal(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Fatal(args...)
 }
+
 func (tl *testLogger) Fatalf(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Fatalf("%s "+format, args...)
 }
+
 func (tl *testLogger) Info(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Info(args...)
 }
+
 func (tl *testLogger) Infof(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Infof("%s "+format, args...)
 }
+
 func (tl *testLogger) Panic(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Panic(args...)
 }
+
 func (tl *testLogger) Panicf(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Panicf("%s "+format, args...)
 }
+
 func (tl *testLogger) Warn(args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Warn(args...)
 }
+
 func (tl *testLogger) Warnf(format string, args ...interface{}) {
 	args = append([]interface{}{tl.name}, args...)
 	tl.l.Warnf("%s "+format, args...)
@@ -138,7 +151,6 @@ func (mb *mockBroadcaster) Broadcast(ctx context.Context, data []byte) error {
 				// Sleep for a very small time that will
 				// effectively be pretty random
 				time.Sleep(time.Nanosecond)
-
 			}
 			timer := time.NewTimer(5 * time.Second)
 			defer timer.Stop()
@@ -198,7 +210,7 @@ func makeStore(t testing.TB, i int) ds.Datastore {
 		return dssync.MutexWrap(ds.NewMapDatastore())
 	case pebbleStore:
 		folder := storeFolder(i)
-		err := os.MkdirAll(folder, 0700)
+		err := os.MkdirAll(folder, 0o700)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -411,9 +423,9 @@ func TestCRDTReplication(t *testing.T) {
 		}
 		t.Log(list)
 	}
-	//replicas[0].PrintDAG()
-	//fmt.Println("==========================================================")
-	//replicas[1].PrintDAG()
+	// replicas[0].PrintDAG()
+	// fmt.Println("==========================================================")
+	// replicas[1].PrintDAG()
 }
 
 // TestCRDTPriority tests that given multiple concurrent updates from several
@@ -482,9 +494,9 @@ func TestCRDTPriority(t *testing.T) {
 		}
 	}
 
-	//replicas[14].PrintDAG()
-	//fmt.Println("=======================================================")
-	//replicas[1].PrintDAG()
+	// replicas[14].PrintDAG()
+	// fmt.Println("=======================================================")
+	// replicas[1].PrintDAG()
 }
 
 func TestCRDTCatchUp(t *testing.T) {
@@ -1386,5 +1398,258 @@ func TestCRDTBatchBroadcast(t *testing.T) {
 
 	if totalHeads != 2 {
 		t.Errorf("Expected 2 heads in broadcast, got %d: %s", totalHeads, heads)
+	}
+}
+
+// nullBroadcaster is a no-op broadcaster for tests that don't need replication.
+// Its Next() blocks until ctx is cancelled, preventing background goroutines
+// from interfering with operations that require exclusive access (e.g. PurgeDAG).
+type nullBroadcaster struct{}
+
+func (nb *nullBroadcaster) Broadcast(_ context.Context, _ []byte) error { return nil }
+func (nb *nullBroadcaster) Next(ctx context.Context) ([]byte, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func makeNReplicasNoBcast(t testing.TB, n int, opts *Options) ([]*Datastore, func()) {
+	bcasts := make([]Broadcaster, n)
+	for i := range bcasts {
+		bcasts[i] = &nullBroadcaster{}
+	}
+	_, cancel := context.WithCancel(t.Context())
+	return makeNReplicasWithBroadcasters(t, n, opts, bcasts, cancel)
+}
+
+func TestPurgeDAG(t *testing.T) {
+	replicas, closeReplicas := makeNReplicasNoBcast(t, 1, nil)
+	t.Cleanup(closeReplicas)
+	replica := replicas[0]
+	mcrdt := MerkleCRDT{replica}
+	ctx := t.Context()
+
+	// Publish one delta under dag1 and two under dag2.
+	k1 := ds.NewKey("key1")
+	delta1, err := replica.set.Add(ctx, k1.String(), []byte("val1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta1.SetDagName("dag1")
+	if _, err := replica.publish(ctx, delta1); err != nil {
+		t.Fatal(err)
+	}
+
+	k2 := ds.NewKey("key2")
+	delta2, err := replica.set.Add(ctx, k2.String(), []byte("val2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta2.SetDagName("dag2")
+	if _, err := replica.publish(ctx, delta2); err != nil {
+		t.Fatal(err)
+	}
+
+	k3 := ds.NewKey("key3")
+	delta3, err := replica.set.Add(ctx, k3.String(), []byte("val3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta3.SetDagName("dag2")
+	if _, err := replica.publish(ctx, delta3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Collect dag1 head CIDs before purge so we can check IsProcessed later.
+	dag1Heads, _, err := replica.heads.ListDAG(ctx, "dag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Purge dag1.
+	n, err := mcrdt.PurgeDAG(ctx, "dag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Error("expected non-zero blocks removed for dag1")
+	}
+
+	// dag1 heads are gone.
+	dag1HeadsAfter, _, err := replica.heads.ListDAG(ctx, "dag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dag1HeadsAfter) != 0 {
+		t.Errorf("expected 0 dag1 heads after purge, got %d", len(dag1HeadsAfter))
+	}
+
+	// dag2 heads remain.
+	dag2Heads, _, err := replica.heads.ListDAG(ctx, "dag2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dag2Heads) != 1 {
+		t.Error("dag2 heads should survive purge of dag1")
+	}
+
+	// Set entry for k1 (dag1 key) is gone.
+	_, err = replica.set.Element(ctx, k1.String())
+	if err != ds.ErrNotFound {
+		t.Errorf("expected ErrNotFound for key1 after purge, got %v", err)
+	}
+
+	// Set entries for dag2 keys remain.
+	if _, err := replica.set.Element(ctx, k2.String()); err != nil {
+		t.Errorf("key2 should survive purge of dag1: %v", err)
+	}
+	if _, err := replica.set.Element(ctx, k3.String()); err != nil {
+		t.Errorf("key3 should survive purge of dag1: %v", err)
+	}
+
+	// Processed block markers for dag1 blocks are gone.
+	for _, h := range dag1Heads {
+		processed, err := mcrdt.IsProcessed(ctx, h.Cid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if processed {
+			t.Errorf("dag1 CID %s should not be processed after purge", h.Cid)
+		}
+	}
+}
+
+func TestPurgeDAGIdempotent(t *testing.T) {
+	replicas, closeReplicas := makeNReplicasNoBcast(t, 1, nil)
+	t.Cleanup(closeReplicas)
+	mcrdt := MerkleCRDT{replicas[0]}
+	ctx := t.Context()
+
+	n, err := mcrdt.PurgeDAG(ctx, "nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 blocks removed for unknown dagName, got %d", n)
+	}
+}
+
+func TestPurgeDAGMixedKey(t *testing.T) {
+	replicas, closeReplicas := makeNReplicasNoBcast(t, 1, nil)
+	t.Cleanup(closeReplicas)
+	replica := replicas[0]
+	mcrdt := MerkleCRDT{replica}
+	ctx := t.Context()
+
+	// Both dag1 and dag2 write to the same key with different values.
+	key := ds.NewKey("shared").String()
+
+	delta1, err := replica.set.Add(ctx, key, []byte("from-dag1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta1.SetDagName("dag1")
+	if _, err := replica.publish(ctx, delta1); err != nil {
+		t.Fatal(err)
+	}
+
+	delta2, err := replica.set.Add(ctx, key, []byte("from-dag2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta2.SetDagName("dag2")
+	if _, err := replica.publish(ctx, delta2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Purge dag2.
+	if _, err := mcrdt.PurgeDAG(ctx, "dag2"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The key should still exist with dag2's value.
+	val, err := replica.set.Element(ctx, key)
+	if err != nil {
+		t.Fatalf("key should survive after purging dag2: %v", err)
+	}
+	if string(val) != "from-dag1" {
+		t.Errorf("expected 'from-dag1', got %q", string(val))
+	}
+}
+
+func TestPurgeDAGCleanStore(t *testing.T) {
+	ctx := t.Context()
+	mapDs := dssync.MutexWrap(ds.NewMapDatastore())
+	dagserv := merkledag.NewDAGService(mdutils.Bserv())
+	dagsync := &mockDAGSvc{
+		DAGService: dagserv,
+		bs:         mdutils.Bserv().Blockstore(),
+	}
+
+	opts := DefaultOptions()
+	opts.Logger = &testLogger{
+		name: "purge-clean: ",
+		l:    DefaultOptions().Logger,
+	}
+
+	namespace := ds.NewKey("crdttest")
+	replica, err := New(mapDs, namespace, dagsync, &nullBroadcaster{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mcrdt := MerkleCRDT{replica}
+
+	// Publish two keys under dag1.
+	delta1, err := replica.set.Add(ctx, "key1", []byte("val1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta1.SetDagName("dag1")
+	if _, err := replica.publish(ctx, delta1); err != nil {
+		t.Fatal(err)
+	}
+	delta2, err := replica.set.Add(ctx, "key2", []byte("val2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delta2.SetDagName("dag1")
+	if _, err := replica.publish(ctx, delta2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Purge dag1.
+	n, err := mcrdt.PurgeDAG(ctx, "dag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatal("expected non-zero blocks removed")
+	}
+
+	// Query all keys remaining in the store.
+	results, err := mapDs.Query(ctx, query.Query{KeysOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { results.Close() })
+
+	var remaining []string
+	for r := range results.Next() {
+		if r.Error != nil {
+			t.Fatal(r.Error)
+		}
+		remaining = append(remaining, r.Key)
+	}
+
+	// The only key that should survive is the version metadata key,
+	// which is Datastore-level state not associated with any dagName.
+	versionKey := namespace.ChildString("crdt_version").String()
+	for _, key := range remaining {
+		if key != versionKey {
+			t.Errorf("unexpected key remaining after purge: %s", key)
+		}
+	}
+	if len(remaining) != 1 {
+		t.Errorf("expected exactly 1 key (version) remaining, got %d: %v", len(remaining), remaining)
 	}
 }

--- a/heads.go
+++ b/heads.go
@@ -24,7 +24,6 @@ type Heads interface {
 	Add(ctx context.Context, head Head) error
 	List(ctx context.Context) ([]Head, uint64, error)
 	ListDAG(ctx context.Context, dagName string) ([]Head, uint64, error)
-	DeleteDAG(ctx context.Context, dagName string) ([]Head, error)
 }
 
 type Head struct {

--- a/heads.go
+++ b/heads.go
@@ -24,6 +24,7 @@ type Heads interface {
 	Add(ctx context.Context, head Head) error
 	List(ctx context.Context) ([]Head, uint64, error)
 	ListDAG(ctx context.Context, dagName string) ([]Head, uint64, error)
+	DeleteDAG(ctx context.Context, dagName string) ([]Head, error)
 }
 
 type Head struct {
@@ -229,6 +230,48 @@ func (hh *heads) List(ctx context.Context) ([]Head, uint64, error) {
 
 func (hh *heads) ListDAG(ctx context.Context, dagName string) ([]Head, uint64, error) {
 	return hh.list(ctx, dagName, true)
+}
+
+// DeleteDAG removes all heads for the given dagName and returns them. The
+// returned heads can be used as traversal roots to remove associated DAG
+// blocks and set entries.
+func (hh *heads) DeleteDAG(ctx context.Context, dagName string) ([]Head, error) {
+	hh.cacheMux.Lock()
+	defer hh.cacheMux.Unlock()
+
+	var store ds.Write = hh.store
+	batchingDs, batching := store.(ds.Batching)
+	var err error
+	if batching {
+		store, err = batchingDs.Batch(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var deleted []Head
+	for c, hv := range hh.cache {
+		if hv.DAGName != dagName {
+			continue
+		}
+		h := Head{Cid: c, HeadValue: hv}
+		if err := hh.delete(ctx, store, h); err != nil {
+			return nil, err
+		}
+		deleted = append(deleted, h)
+	}
+
+	if batching {
+		if err := store.(ds.Batch).Commit(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, h := range deleted {
+		delete(hh.cache, h.Cid)
+	}
+
+	return deleted, nil
 }
 
 // primeCache builds the heads cache based on what's in storage; since

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -237,30 +237,12 @@ func (mcrdt *MerkleCRDT) IsProcessed(ctx context.Context, c cid.Cid) (bool, erro
 	return mcrdt.isProcessed(ctx, c)
 }
 
-// TraverseOptions configures the behavior of Traverse and TraverseWithOptions.
-type TraverseOptions struct {
-	// DisableSkipDuplicates disables the built-in duplicate tracking in the
-	// traversal library. Callers that maintain their own visited set can
-	// use this to avoid keeping two copies of every CID in memory.
-	DisableSkipDuplicates bool
-}
-
 // Traverse visits nodes in the Merkle-CRDT tree. It skips duplicates
 // and calls the visit function with the Deltas extracted from every
 // node. An error results in the traversal operations being aborted.
 func (mcrdt *MerkleCRDT) Traverse(ctx context.Context,
 	from []cid.Cid,
 	visit func(ipld.Node) error,
-) error {
-	return mcrdt.TraverseWithOptions(ctx, from, visit, TraverseOptions{})
-}
-
-// TraverseWithOptions is like Traverse but accepts a TraverseOptions to
-// configure traversal behavior.
-func (mcrdt *MerkleCRDT) TraverseWithOptions(ctx context.Context,
-	from []cid.Cid,
-	visit func(ipld.Node) error,
-	opts TraverseOptions,
 ) error {
 	if len(from) == 0 {
 		return errors.New("no roots to traverse from")
@@ -306,13 +288,13 @@ func (mcrdt *MerkleCRDT) TraverseWithOptions(ctx context.Context,
 		ignoreCid = root.Cid() // tFunc will skip this.
 	}
 
-	travOpts := traverse.Options{
+	opts := traverse.Options{
 		DAG:            mcrdt.dagService,
 		Order:          traverse.DFSPre, // default
 		Func:           tFunc,
 		ErrFunc:        tErrFunc,
-		SkipDuplicates: !opts.DisableSkipDuplicates,
+		SkipDuplicates: true,
 	}
 
-	return traverse.Traverse(root, travOpts)
+	return traverse.Traverse(root, opts)
 }

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -72,7 +72,7 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 	}
 
 	for key := range setKeys {
-		if err := mcrdt.set.PurgeKeyBlocks(ctx, key, dagCIDSet); err != nil {
+		if err := mcrdt.set.purgeKeyBlocks(ctx, key, dagCIDSet); err != nil {
 			return 0, err
 		}
 	}

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -14,21 +14,24 @@ import (
 // blocks reachable from those heads, the set entries created by those blocks,
 // and processed block markers. Returns the number of DAG nodes removed.
 //
+// Heads are deleted last so that a partial failure leaves them intact and a
+// subsequent call can resume the cleanup.
+//
 // The caller must ensure no concurrent writes to this dagName during purge.
 // The Datastore's background workers (rebroadcast, repair, DAG walking) also
 // access heads and set state — callers should either Close() the Datastore
 // first or ensure the dagName is not being actively synced.
 func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, error) {
-	deletedHeads, err := mcrdt.heads.DeleteDAG(ctx, dagName)
+	currentHeads, _, err := mcrdt.heads.ListDAG(ctx, dagName)
 	if err != nil {
 		return 0, err
 	}
-	if len(deletedHeads) == 0 {
+	if len(currentHeads) == 0 {
 		return 0, nil
 	}
 
-	headCIDs := make([]cid.Cid, len(deletedHeads))
-	for i, h := range deletedHeads {
+	headCIDs := make([]cid.Cid, len(currentHeads))
+	for i, h := range currentHeads {
 		headCIDs[i] = h.Cid
 	}
 
@@ -111,6 +114,10 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 	}
 
 	if err := mcrdt.dagService.RemoveMany(ctx, dagCIDs); err != nil {
+		return 0, err
+	}
+
+	if _, err := mcrdt.heads.DeleteDAG(ctx, dagName); err != nil {
 		return 0, err
 	}
 

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -33,7 +33,16 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 	}
 
 	dagCIDSet := make(map[cid.Cid]struct{})
-	setKeys := make(map[string]struct{})
+
+	// purgeKeyKind tracks which namespaces a key appeared in across the DAG's
+	// deltas, so purgeKeyBlocks can skip querying namespaces that the DAG never
+	// wrote to for a given key.
+	type purgeKeyKind uint8
+	const (
+		purgeKeyElem purgeKeyKind = 1 << iota
+		purgeKeyTomb
+	)
+	setKeys := make(map[string]purgeKeyKind)
 
 	if err := mcrdt.TraverseWithOptions(ctx, headCIDs, func(nd ipld.Node) error {
 		c := nd.Cid()
@@ -56,7 +65,7 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 			return err
 		}
 		for _, e := range elems {
-			setKeys[e.GetKey()] = struct{}{}
+			setKeys[e.GetKey()] |= purgeKeyElem
 		}
 
 		tombs, err := delta.GetTombstones()
@@ -64,15 +73,15 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 			return err
 		}
 		for _, t := range tombs {
-			setKeys[t.GetKey()] = struct{}{}
+			setKeys[t.GetKey()] |= purgeKeyTomb
 		}
 		return nil
 	}, TraverseOptions{DisableSkipDuplicates: true}); err != nil {
 		return 0, err
 	}
 
-	for key := range setKeys {
-		if err := mcrdt.set.purgeKeyBlocks(ctx, key, dagCIDSet); err != nil {
+	for key, kind := range setKeys {
+		if err := mcrdt.set.purgeKeyBlocks(ctx, key, dagCIDSet, kind&purgeKeyElem != 0, kind&purgeKeyTomb != 0); err != nil {
 			return 0, err
 		}
 	}

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -10,6 +10,104 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+// PurgeDAG removes all state associated with a named DAG: its heads, all DAG
+// blocks reachable from those heads, the set entries created by those blocks,
+// and processed block markers. Returns the number of DAG nodes removed.
+//
+// The caller must ensure no concurrent writes to this dagName during purge.
+// The Datastore's background workers (rebroadcast, repair, DAG walking) also
+// access heads and set state — callers should either Close() the Datastore
+// first or ensure the dagName is not being actively synced.
+func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, error) {
+	deletedHeads, err := mcrdt.heads.DeleteDAG(ctx, dagName)
+	if err != nil {
+		return 0, err
+	}
+	if len(deletedHeads) == 0 {
+		return 0, nil
+	}
+
+	headCIDs := make([]cid.Cid, len(deletedHeads))
+	for i, h := range deletedHeads {
+		headCIDs[i] = h.Cid
+	}
+
+	dagCIDSet := make(map[cid.Cid]struct{})
+	setKeys := make(map[string]struct{})
+
+	if err := mcrdt.TraverseWithOptions(ctx, headCIDs, func(nd ipld.Node) error {
+		c := nd.Cid()
+		if _, seen := dagCIDSet[c]; seen {
+			return nil
+		}
+		dagCIDSet[c] = struct{}{}
+
+		deltaBytes, err := extractDelta(nd)
+		if err != nil {
+			return err
+		}
+		delta := mcrdt.newDelta()
+		if err := delta.Unmarshal(deltaBytes); err != nil {
+			return err
+		}
+
+		elems, err := delta.GetElements()
+		if err != nil {
+			return err
+		}
+		for _, e := range elems {
+			setKeys[e.GetKey()] = struct{}{}
+		}
+
+		tombs, err := delta.GetTombstones()
+		if err != nil {
+			return err
+		}
+		for _, t := range tombs {
+			setKeys[t.GetKey()] = struct{}{}
+		}
+		return nil
+	}, TraverseOptions{DisableSkipDuplicates: true}); err != nil {
+		return 0, err
+	}
+
+	for key := range setKeys {
+		if err := mcrdt.set.PurgeKeyBlocks(ctx, key, dagCIDSet); err != nil {
+			return 0, err
+		}
+	}
+
+	dagCIDs := make([]cid.Cid, 0, len(dagCIDSet))
+	for c := range dagCIDSet {
+		dagCIDs = append(dagCIDs, c)
+	}
+
+	var store ds.Write = mcrdt.store
+	batchingDs, batching := store.(ds.Batching)
+	if batching {
+		store, err = batchingDs.Batch(ctx)
+		if err != nil {
+			return 0, err
+		}
+	}
+	for _, c := range dagCIDs {
+		if err := store.Delete(ctx, mcrdt.processedBlockKey(c)); err != nil {
+			return 0, err
+		}
+	}
+	if batching {
+		if err := store.(ds.Batch).Commit(ctx); err != nil {
+			return 0, err
+		}
+	}
+
+	if err := mcrdt.dagService.RemoveMany(ctx, dagCIDs); err != nil {
+		return 0, err
+	}
+
+	return len(dagCIDs), nil
+}
+
 // DatatstoreNamespaces carries configuration for how internal namespaces are named.
 type InternalNamespaces struct {
 	Heads           string
@@ -43,7 +141,6 @@ func NewMerkleCRDT(
 	opts *Options,
 	internalOptions *MerkleCRDTOptions,
 ) (*MerkleCRDT, error) {
-
 	if opts == nil {
 		opts = DefaultOptions()
 	}
@@ -104,12 +201,30 @@ func (mcrdt *MerkleCRDT) IsProcessed(ctx context.Context, c cid.Cid) (bool, erro
 	return mcrdt.isProcessed(ctx, c)
 }
 
+// TraverseOptions configures the behavior of Traverse and TraverseWithOptions.
+type TraverseOptions struct {
+	// DisableSkipDuplicates disables the built-in duplicate tracking in the
+	// traversal library. Callers that maintain their own visited set can
+	// use this to avoid keeping two copies of every CID in memory.
+	DisableSkipDuplicates bool
+}
+
 // Traverse visits nodes in the Merkle-CRDT tree. It skips duplicates
 // and calls the visit function with the Deltas extracted from every
 // node. An error results in the traversal operations being aborted.
 func (mcrdt *MerkleCRDT) Traverse(ctx context.Context,
 	from []cid.Cid,
 	visit func(ipld.Node) error,
+) error {
+	return mcrdt.TraverseWithOptions(ctx, from, visit, TraverseOptions{})
+}
+
+// TraverseWithOptions is like Traverse but accepts a TraverseOptions to
+// configure traversal behavior.
+func (mcrdt *MerkleCRDT) TraverseWithOptions(ctx context.Context,
+	from []cid.Cid,
+	visit func(ipld.Node) error,
+	opts TraverseOptions,
 ) error {
 	if len(from) == 0 {
 		return errors.New("no roots to traverse from")
@@ -155,13 +270,13 @@ func (mcrdt *MerkleCRDT) Traverse(ctx context.Context,
 		ignoreCid = root.Cid() // tFunc will skip this.
 	}
 
-	opts := traverse.Options{
+	travOpts := traverse.Options{
 		DAG:            mcrdt.dagService,
 		Order:          traverse.DFSPre, // default
 		Func:           tFunc,
 		ErrFunc:        tErrFunc,
-		SkipDuplicates: true,
+		SkipDuplicates: !opts.DisableSkipDuplicates,
 	}
 
-	return traverse.Traverse(root, opts)
+	return traverse.Traverse(root, travOpts)
 }

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -47,25 +47,44 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 	)
 	setKeys := make(map[string]purgeKeyKind)
 
-	if err := mcrdt.TraverseWithOptions(ctx, headCIDs, func(nd ipld.Node) error {
-		c := nd.Cid()
+	// Walk the DAG with a local-only DFS: check isProcessed before fetching each
+	// block so we never trigger network requests. Unprocessed blocks have no set
+	// state to clean up, so skipping them is correct.
+	stack := make([]cid.Cid, len(headCIDs))
+	copy(stack, headCIDs)
+	for len(stack) > 0 {
+		c := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
 		if _, seen := dagCIDSet[c]; seen {
-			return nil
+			continue
+		}
+		processed, err := mcrdt.isProcessed(ctx, c)
+		if err != nil {
+			return 0, err
+		}
+		if !processed {
+			continue
 		}
 		dagCIDSet[c] = struct{}{}
 
+		nd, err := mcrdt.dagService.Get(ctx, c)
+		if err != nil {
+			return 0, err
+		}
+
 		deltaBytes, err := extractDelta(nd)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		delta := mcrdt.newDelta()
 		if err := delta.Unmarshal(deltaBytes); err != nil {
-			return err
+			return 0, err
 		}
 
 		elems, err := delta.GetElements()
 		if err != nil {
-			return err
+			return 0, err
 		}
 		for _, e := range elems {
 			setKeys[e.GetKey()] |= purgeKeyElem
@@ -73,14 +92,15 @@ func (mcrdt *MerkleCRDT) PurgeDAG(ctx context.Context, dagName string) (int, err
 
 		tombs, err := delta.GetTombstones()
 		if err != nil {
-			return err
+			return 0, err
 		}
 		for _, t := range tombs {
 			setKeys[t.GetKey()] |= purgeKeyTomb
 		}
-		return nil
-	}, TraverseOptions{DisableSkipDuplicates: true}); err != nil {
-		return 0, err
+
+		for _, link := range nd.Links() {
+			stack = append(stack, link.Cid)
+		}
 	}
 
 	for key, kind := range setKeys {

--- a/set.go
+++ b/set.go
@@ -66,7 +66,6 @@ func newCRDTSet(
 	deleteHook func(key string),
 	deltaFactory func() Delta,
 ) (*set, error) {
-
 	set := &set{
 		namespace:    namespace,
 		store:        d,
@@ -669,6 +668,104 @@ func (s *set) inTombsKeyID(ctx context.Context, key, id string) (bool, error) {
 
 // 	return s.inElemsKeyID(key, id)
 // }
+
+// PurgeKeyBlocks removes element and tombstone entries for the given key that
+// were created by any of the given block CIDs. After removal, it recomputes
+// the best value from surviving elements. If no elements survive, the key's
+// value and priority are deleted.
+func (s *set) PurgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.Cid]struct{}) error {
+	s.putElemsMux.Lock()
+	defer s.putElemsMux.Unlock()
+
+	var store ds.Write = s.store
+	batchingDs, batching := store.(ds.Batching)
+	var err error
+	if batching {
+		store, err = batchingDs.Batch(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	deleteMatchingIDs := func(prefix ds.Key) error {
+		q := query.Query{
+			Prefix:   prefix.String(),
+			KeysOnly: true,
+		}
+		results, err := s.store.Query(ctx, q)
+		if err != nil {
+			return err
+		}
+		defer results.Close() //nolint:errcheck
+
+		for r := range results.Next() {
+			if r.Error != nil {
+				return r.Error
+			}
+			id := strings.TrimPrefix(r.Key, prefix.String())
+			if !ds.RawKey(id).IsTopLevel() {
+				continue
+			}
+			mhash, err := dshelp.DsKeyToMultihash(ds.NewKey(id))
+			if err != nil {
+				return err
+			}
+			c := cid.NewCidV1(cid.DagProtobuf, mhash)
+			if _, ok := blockCIDs[c]; !ok {
+				continue
+			}
+			if err := store.Delete(ctx, prefix.ChildString(id)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := deleteMatchingIDs(s.elemsPrefix(key)); err != nil {
+		return err
+	}
+	if err := deleteMatchingIDs(s.tombsPrefix(key)); err != nil {
+		return err
+	}
+
+	if batching {
+		if err := store.(ds.Batch).Commit(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Recompute best value from surviving elements. Entries are already
+	// deleted from the store, so nil pendingTombIDs is correct.
+	bestVal, bestPrio, err := s.findBestValue(ctx, key, nil)
+	if err != nil {
+		return err
+	}
+
+	valueK := s.valueKey(key)
+	if bestVal == nil {
+		var errs []error
+		if err := s.store.Delete(ctx, valueK); err != nil && err != ds.ErrNotFound {
+			errs = append(errs, err)
+		}
+		if err := s.store.Delete(ctx, s.priorityKey(key)); err != nil && err != ds.ErrNotFound {
+			errs = append(errs, err)
+		}
+		if err := errors.Join(errs...); err != nil {
+			return err
+		}
+		s.deleteHook(key)
+	} else {
+		if err := s.store.Put(ctx, valueK, bestVal); err != nil {
+			return err
+		}
+		if err := s.setPriority(ctx, s.store, key, bestPrio); err != nil {
+			return err
+		}
+		s.putHook(key, bestVal)
+	}
+
+	return nil
+}
 
 // perform a sync against all the paths associated with a key prefix
 func (s *set) datastoreSync(ctx context.Context, prefix ds.Key) error {

--- a/set.go
+++ b/set.go
@@ -673,7 +673,11 @@ func (s *set) inTombsKeyID(ctx context.Context, key, id string) (bool, error) {
 // were created by any of the given block CIDs. After removal, it recomputes
 // the best value from surviving elements. If no elements survive, the key's
 // value and priority are deleted.
-func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.Cid]struct{}) error {
+//
+// hasElems and hasTombs indicate which namespaces the DAG being purged
+// actually wrote entries for this key; passing false for either skips the
+// corresponding datastore query.
+func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.Cid]struct{}, hasElems, hasTombs bool) error {
 	s.putElemsMux.Lock()
 	defer s.putElemsMux.Unlock()
 
@@ -731,11 +735,15 @@ func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.
 		return nil
 	}
 
-	if err := deleteMatchingIDs(s.elemsPrefix(key)); err != nil {
-		return err
+	if hasElems {
+		if err := deleteMatchingIDs(s.elemsPrefix(key)); err != nil {
+			return err
+		}
 	}
-	if err := deleteMatchingIDs(s.tombsPrefix(key)); err != nil {
-		return err
+	if hasTombs {
+		if err := deleteMatchingIDs(s.tombsPrefix(key)); err != nil {
+			return err
+		}
 	}
 
 	if batching {

--- a/set.go
+++ b/set.go
@@ -669,11 +669,11 @@ func (s *set) inTombsKeyID(ctx context.Context, key, id string) (bool, error) {
 // 	return s.inElemsKeyID(key, id)
 // }
 
-// PurgeKeyBlocks removes element and tombstone entries for the given key that
+// purgeKeyBlocks removes element and tombstone entries for the given key that
 // were created by any of the given block CIDs. After removal, it recomputes
 // the best value from surviving elements. If no elements survive, the key's
 // value and priority are deleted.
-func (s *set) PurgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.Cid]struct{}) error {
+func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.Cid]struct{}) error {
 	s.putElemsMux.Lock()
 	defer s.putElemsMux.Unlock()
 

--- a/set.go
+++ b/set.go
@@ -702,11 +702,21 @@ func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.
 			if r.Error != nil {
 				return r.Error
 			}
-			id := strings.TrimPrefix(r.Key, prefix.String())
-			if !ds.RawKey(id).IsTopLevel() {
+			// Strip the query prefix to get the relative remainder, which for a
+			// direct child is just the block ID (a CID encoded as a datastore key
+			// string): "/namespace/s/foo/<blockID>" → "/<blockID>".
+			blockID := strings.TrimPrefix(r.Key, prefix.String())
+			// The prefix query also returns entries for child keys: prefix "foo"
+			// matches both "foo/<block>" and "foo/bar/<block>". After trimming, a
+			// direct child yields a top-level key "/<blockID>", while a grandchild
+			// yields "/bar/<blockID>". Reject the latter since it belongs to a
+			// different key.
+			if !ds.RawKey(blockID).IsTopLevel() {
 				continue
 			}
-			mhash, err := dshelp.DsKeyToMultihash(ds.NewKey(id))
+			// Decode the datastore key back into a CID so we can look it up in the
+			// caller-supplied set.
+			mhash, err := dshelp.DsKeyToMultihash(ds.NewKey(blockID))
 			if err != nil {
 				return err
 			}
@@ -714,7 +724,7 @@ func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.
 			if _, ok := blockCIDs[c]; !ok {
 				continue
 			}
-			if err := store.Delete(ctx, prefix.ChildString(id)); err != nil {
+			if err := store.Delete(ctx, prefix.ChildString(blockID)); err != nil {
 				return err
 			}
 		}

--- a/set.go
+++ b/set.go
@@ -410,7 +410,7 @@ func (s *set) findBestValue(ctx context.Context, key string, pendingTombIDs []st
 NEXT:
 	for r := range results.Next() {
 		if r.Error != nil {
-			return nil, 0, err
+			return nil, 0, r.Error
 		}
 
 		id := strings.TrimPrefix(r.Key, prefix.String())
@@ -746,6 +746,10 @@ func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.
 		}
 	}
 
+	// The delete batch and the value/priority rewrite below are not atomic.
+	// A crash between them leaves a stale value key, but PurgeDAG is
+	// idempotent: a retry will skip the already-deleted entries and rewrite
+	// the value correctly.
 	if batching {
 		if err := store.(ds.Batch).Commit(ctx); err != nil {
 			return err
@@ -762,10 +766,10 @@ func (s *set) purgeKeyBlocks(ctx context.Context, key string, blockCIDs map[cid.
 	valueK := s.valueKey(key)
 	if bestVal == nil {
 		var errs []error
-		if err := s.store.Delete(ctx, valueK); err != nil && err != ds.ErrNotFound {
+		if err := s.store.Delete(ctx, valueK); err != nil && errors.Is(err, ds.ErrNotFound) {
 			errs = append(errs, err)
 		}
-		if err := s.store.Delete(ctx, s.priorityKey(key)); err != nil && err != ds.ErrNotFound {
+		if err := s.store.Delete(ctx, s.priorityKey(key)); err != nil && errors.Is(err, ds.ErrNotFound) {
 			errs = append(errs, err)
 		}
 		if err := errors.Join(errs...); err != nil {


### PR DESCRIPTION
Adds `MerkleCRDT.PurgeDAG(ctx, dagName)` which hard-deletes all internal state for a given dagName: heads, DAG blocks, set entries (elements, tombstones, value/priority), and processed block markers.

Unlike the existing soft-delete (tombstoning), this physically removes the data for admin/maintenance use cases.

Also adds `TraverseWithOptions` to allow callers to disable the traversal library's built-in duplicate tracking when they maintain their own visited set.