### PR TITLE
fix: detect abnormal shutdown and trigger repair on next start

### DIFF
--- a/crdt.go
+++ b/crdt.go
@@ -369,10 +369,17 @@ func New(
 		dstore.MarkDirty(ctx)
 	}
 	// Set the bad-shutdown key so that if we crash before the next clean
-	// Close(), we will know on the next startup and trigger a repair.
+	// Close(), we will know on the next startup and trigger a repair. Sync it to
+	// disk immediately, otherwise a crash before the next flush would leave the
+	// marker only in memory and the crash would go undetected on the next
+	// startup.
 	if err := dstore.store.Put(ctx, dstore.badShutdownKey(), nil); err != nil {
 		cancel()
 		return nil, fmt.Errorf("error writing bad-shutdown key: %w", err)
+	}
+	if err := dstore.store.Sync(ctx, dstore.badShutdownKey()); err != nil {
+		cancel()
+		return nil, fmt.Errorf("error syncing bad-shutdown key: %w", err)
 	}
 
 	headList, maxHeight, err := dstore.heads.List(ctx)
@@ -1371,6 +1378,8 @@ func (store *Datastore) Close() error {
 	// land. Use a background context — store.ctx was cancelled above.
 	if err := store.store.Delete(closeCtx, store.badShutdownKey()); err != nil {
 		store.logger.Errorf("error clearing bad-shutdown key: %s", err)
+	} else if err := store.store.Sync(closeCtx, store.badShutdownKey()); err != nil {
+		store.logger.Errorf("error syncing bad-shutdown key deletion: %s", err)
 	}
 	return nil
 }

--- a/crdt.go
+++ b/crdt.go
@@ -45,11 +45,12 @@ var (
 
 // datastore namespace keys. Short keys save space and memory.
 const (
-	headsNs           = "h" // heads
-	dagHeadsNs        = "a" // dagHeads - heads for named dags.
-	setNs             = "s" // set
-	processedBlocksNs = "b" // blocks
-	dirtyBitKey       = "d" // dirty
+	headsNs           = "h"  // heads
+	dagHeadsNs        = "a"  // dagHeads - heads for named dags.
+	setNs             = "s"  // set
+	processedBlocksNs = "b"  // blocks
+	dirtyBitKey       = "d"  // dirty
+	badShutdownKey    = "bs" // bad-shutdown: set on New, cleared on clean Close
 	versionKey        = "crdt_version"
 )
 
@@ -173,6 +174,7 @@ func (opts *Options) verify() error {
 		opts.crdtOpts.Namespaces.Set == "",
 		opts.crdtOpts.Namespaces.ProcessedBlocks == "",
 		opts.crdtOpts.Namespaces.DirtyBitKey == "",
+		opts.crdtOpts.Namespaces.BadShutdownKey == "",
 		opts.crdtOpts.Namespaces.VersionKey == "":
 		panic("one or several InternalNamespaces are unset, and this should never happen")
 	}
@@ -205,6 +207,7 @@ func DefaultOptions() *Options {
 				Set:             setNs,
 				ProcessedBlocks: processedBlocksNs,
 				DirtyBitKey:     dirtyBitKey,
+				BadShutdownKey:  badShutdownKey,
 				VersionKey:      versionKey,
 			},
 		},
@@ -350,6 +353,26 @@ func New(
 	if err != nil {
 		cancel()
 		return nil, err
+	}
+
+	// Detect whether the previous run ended with a clean Close(). If the
+	// bad-shutdown key is present at startup, the process died without clearing
+	// it (crash, kill, OOM, power loss); mark the store dirty so the repair loop
+	// walks the DAG and recovers any partially-processed branches.
+	hadBadShutdown, err := dstore.store.Has(ctx, dstore.badShutdownKey())
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("error checking bad-shutdown key: %w", err)
+	}
+	if hadBadShutdown {
+		dstore.logger.Warn("previous shutdown was not clean; marking datastore as dirty to trigger repair")
+		dstore.MarkDirty(ctx)
+	}
+	// Set the bad-shutdown key so that if we crash before the next clean
+	// Close(), we will know on the next startup and trigger a repair.
+	if err := dstore.store.Put(ctx, dstore.badShutdownKey(), nil); err != nil {
+		cancel()
+		return nil, fmt.Errorf("error writing bad-shutdown key: %w", err)
 	}
 
 	headList, maxHeight, err := dstore.heads.List(ctx)
@@ -950,6 +973,13 @@ func (store *Datastore) dirtyKey() ds.Key {
 	return store.namespace.ChildString(store.opts.crdtOpts.Namespaces.DirtyBitKey)
 }
 
+// badShutdownKey is written on New and removed on a clean Close. Its presence
+// at startup indicates the previous run did not Close() cleanly, so the store
+// should be treated as dirty and repaired.
+func (store *Datastore) badShutdownKey() ds.Key {
+	return store.namespace.ChildString(store.opts.crdtOpts.Namespaces.BadShutdownKey)
+}
+
 // MarkDirty marks the Datastore as dirty.
 func (store *Datastore) MarkDirty(ctx context.Context) {
 	store.logger.Warn("marking datastore as dirty")
@@ -1330,10 +1360,17 @@ func (store *Datastore) Sync(ctx context.Context, prefix ds.Key) error {
 
 // Close shuts down the CRDT datastore. It should not be used afterwards.
 func (store *Datastore) Close() error {
+	closeCtx := context.Background()
 	store.cancel()
 	store.wg.Wait()
-	if store.IsDirty(store.ctx) {
+	if store.IsDirty(closeCtx) {
 		store.logger.Warn("datastore is being closed marked as dirty")
+	}
+	// Clear the bad-shutdown key last, after all workers have exited, so
+	// any dirty marks they still needed to write have had a chance to
+	// land. Use a background context — store.ctx was cancelled above.
+	if err := store.store.Delete(closeCtx, store.badShutdownKey()); err != nil {
+		store.logger.Errorf("error clearing bad-shutdown key: %s", err)
 	}
 	return nil
 }

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	blockstore "github.com/ipfs/boxo/blockstore"
@@ -1641,15 +1642,189 @@ func TestPurgeDAGCleanStore(t *testing.T) {
 		remaining = append(remaining, r.Key)
 	}
 
-	// The only key that should survive is the version metadata key,
-	// which is Datastore-level state not associated with any dagName.
-	versionKey := namespace.ChildString("crdt_version").String()
+	// The only keys that should survive are datastore-level metadata keys
+	// not associated with any dagName: the version key and the
+	// bad-shutdown key (written by New and cleared by Close).
+	allowed := map[string]bool{
+		namespace.ChildString(versionKey).String():     true,
+		namespace.ChildString(badShutdownKey).String(): true,
+	}
 	for _, key := range remaining {
-		if key != versionKey {
+		if !allowed[key] {
 			t.Errorf("unexpected key remaining after purge: %s", key)
 		}
 	}
-	if len(remaining) != 1 {
-		t.Errorf("expected exactly 1 key (version) remaining, got %d: %v", len(remaining), remaining)
+	if len(remaining) != len(allowed) {
+		t.Errorf("expected exactly %d datastore-level keys remaining, got %d: %v", len(allowed), len(remaining), remaining)
 	}
+}
+
+// openTestStore opens a Datastore on the given underlying ds/dagservice with
+// sensible defaults for the bad-shutdown tests (null broadcaster, short
+// repair interval when requested).
+func openTestStore(t testing.TB, name string, mapDs ds.Datastore, dagServ ipld.DAGService, repair time.Duration) *Datastore {
+	t.Helper()
+	opts := DefaultOptions()
+	opts.Logger = &testLogger{name: name + ": ", l: DefaultOptions().Logger}
+	opts.RepairInterval = repair
+	opts.RebroadcastInterval = time.Hour // disable rebroadcast noise
+	d, err := New(mapDs, ds.NewKey("crdttest"), dagServ, &nullBroadcaster{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// TestBadShutdownMark_CleanCloseNoDirty verifies that on a clean
+// New/Close/New cycle, the store is never marked dirty. The bad-shutdown
+// key is present while a Datastore is open and removed by Close.
+func TestBadShutdownMark_CleanCloseNoDirty(t *testing.T) {
+	ctx := t.Context()
+	mapDs := dssync.MutexWrap(ds.NewMapDatastore())
+	dagServ := merkledag.NewDAGService(mdutils.Bserv())
+	bsKey := ds.NewKey("crdttest").ChildString(badShutdownKey)
+
+	d1 := openTestStore(t, "r1", mapDs, dagServ, time.Hour)
+	has, err := mapDs.Has(ctx, bsKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Fatal("bad-shutdown key should be present after New")
+	}
+	if d1.IsDirty(ctx) {
+		t.Fatal("store should not be dirty on a fresh open")
+	}
+	if err := d1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	has, err = mapDs.Has(ctx, bsKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if has {
+		t.Fatal("bad-shutdown key should be cleared by a clean Close")
+	}
+
+	d2 := openTestStore(t, "r2", mapDs, dagServ, time.Hour)
+	if d2.IsDirty(ctx) {
+		t.Fatal("store should not be dirty after a clean prior Close")
+	}
+	if err := d2.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBadShutdownMark_DetectedOnStartup verifies that if the bad-shutdown
+// key is present at startup (simulating a previous run that crashed before
+// Close), the store is marked dirty and the key is re-armed for the next
+// run.
+func TestBadShutdownMark_DetectedOnStartup(t *testing.T) {
+	ctx := t.Context()
+	mapDs := dssync.MutexWrap(ds.NewMapDatastore())
+	dagServ := merkledag.NewDAGService(mdutils.Bserv())
+	bsKey := ds.NewKey("crdttest").ChildString(badShutdownKey)
+
+	// Simulate state left behind by a crashed prior run: bs key present,
+	// no clean Close ever ran.
+	if err := mapDs.Put(ctx, bsKey, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	d := openTestStore(t, "recover", mapDs, dagServ, time.Hour)
+	defer func() { _ = d.Close() }()
+
+	if !d.IsDirty(ctx) {
+		t.Fatal("store should be dirty after detecting a prior bad shutdown")
+	}
+	has, err := mapDs.Has(ctx, bsKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Fatal("bad-shutdown key should still be present (re-armed for next run)")
+	}
+}
+
+// TestBadShutdownMark_PartialBranchRecovery builds a 2-node chain, fetches
+// the head's child, corrupts the datastore by deleting the child's processed
+// marker, and asserts that on reopen the bad-shutdown mark triggers a repair
+// that restores the missing state.
+func TestBadShutdownMark_PartialBranchRecovery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		mapDs := dssync.MutexWrap(ds.NewMapDatastore())
+		dagServ := merkledag.NewDAGService(mdutils.Bserv())
+
+		d1 := openTestStore(t, "r1", mapDs, dagServ, time.Hour)
+		if err := d1.Put(ctx, ds.NewKey("/k1"), []byte("v1")); err != nil {
+			t.Fatal(err)
+		}
+		if err := d1.Put(ctx, ds.NewKey("/k2"), []byte("v2")); err != nil {
+			t.Fatal(err)
+		}
+
+		headsList, _, err := d1.heads.List(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(headsList) != 1 {
+			t.Fatalf("expected exactly 1 head after two sequential Puts, got %d", len(headsList))
+		}
+		headCid := headsList[0].Cid
+
+		headNode, err := dagServ.Get(ctx, headCid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		links := headNode.Links()
+		if len(links) == 0 {
+			t.Fatal("head node should link to at least one prior block")
+		}
+		childCid := links[0].Cid
+		childProcessedKey := d1.processedBlockKey(childCid)
+
+		for _, c := range []cid.Cid{headCid, childCid} {
+			ok, err := d1.isProcessed(ctx, c)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatalf("block %s should be processed before corruption", c)
+			}
+		}
+		if err := d1.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Corrupt the datastore: drop the child's processed marker and
+		// re-arm the bad-shutdown key so reopen detects an unclean prior
+		// run.
+		if err := mapDs.Delete(ctx, childProcessedKey); err != nil {
+			t.Fatal(err)
+		}
+		if err := mapDs.Put(ctx, ds.NewKey("crdttest").ChildString(badShutdownKey), nil); err != nil {
+			t.Fatal(err)
+		}
+
+		d2 := openTestStore(t, "r2", mapDs, dagServ, time.Hour)
+		t.Cleanup(func() { _ = d2.Close() })
+
+		if !d2.IsDirty(ctx) {
+			t.Fatal("store should be dirty after detecting a prior bad shutdown")
+		}
+
+		synctest.Wait()
+
+		ok, err := d2.isProcessed(ctx, childCid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("child should be processed after repair")
+		}
+		if d2.IsDirty(ctx) {
+			t.Fatal("store should be marked clean after successful repair")
+		}
+	})
 }

--- a/merklecrdt.go
+++ b/merklecrdt.go
@@ -151,6 +151,7 @@ type InternalNamespaces struct {
 	Set             string
 	ProcessedBlocks string
 	DirtyBitKey     string
+	BadShutdownKey  string
 	VersionKey      string
 }
 
@@ -199,6 +200,9 @@ func NewMerkleCRDT(
 		}
 		if ns := in.DirtyBitKey; ns != "" {
 			opts.crdtOpts.Namespaces.DirtyBitKey = ns
+		}
+		if ns := in.BadShutdownKey; ns != "" {
+			opts.crdtOpts.Namespaces.BadShutdownKey = ns
 		}
 		if ns := in.VersionKey; ns != "" {
 			opts.crdtOpts.Namespaces.VersionKey = ns


### PR DESCRIPTION
Fix suggested in https://github.com/ipfs/go-ds-crdt/issues/279#issuecomment-2895765190

## Problem

A CRDT replica can be left in a silently inconsistent state after an abnormal termination (SIGKILL, OOM, panic without `Close()`, power loss).

## Fix

Persist a single key, `/<namespace>/bs`, whose presence at startup means "the previous run did not close cleanly":

* **Startup**: if the key is present, `MarkDirty` the store (so repair runs) and log a warning. Then write the key unconditionally so a crash in this run is caught on the next start.
* **Clean `Close()`**: after `wg.Wait()` (so any worker still marking dirty during shutdown has finished), delete the key as the last step.

No changes to the walk/merge hot path, `MarkDirty`/`IsDirty` signatures, or `repairDAG` scope.