### PR TITLE
fix: add branch tip to heads in handleBranch

### DIFF
--- a/crdt.go
+++ b/crdt.go
@@ -797,6 +797,36 @@ func (store *Datastore) handleBranch(ctx context.Context, head Head, c cid.Cid) 
 		dg = &crdtNodeGetter{NodeGetter: sessionMaker.Session(cctx)}
 	}
 
+	// Pre-register the new head before walking the branch. The existing
+	// head-promotion logic in processNode only fires once the walk reaches
+	// the bottom (heads.Replace at the old head, or heads.Add at a
+	// genesis/already-queued node), which can be many nodes deep. If the
+	// process crashes or is closed cleanly mid-walk, the new head would
+	// otherwise never be persisted, the merged-but-unfinished branch would
+	// stay marked as processed, and repairDAG (which walks from heads
+	// only) would be unable to reach it. Pre-registering means a partial
+	// walk leaves a recoverable trace: repair will find the new head and
+	// re-walk down to fill in the unprocessed portion.
+	//
+	// Skip when head.Cid != c (called from repairDAG mid-branch) or when
+	// the CID is already a head (idempotent fast path).
+	if head.Cid == c {
+		if _, isHead := store.heads.Get(ctx, head.Cid); !isHead {
+			if head.Height == 0 {
+				prioCtx, prioCancel := context.WithTimeout(ctx, store.opts.DAGSyncerTimeout)
+				prio, err := store.getPriority(prioCtx, dg, c)
+				prioCancel()
+				if err != nil {
+					return fmt.Errorf("error getting priority for new head %s: %w", c, err)
+				}
+				head.Height = prio
+			}
+			if err := store.heads.Add(ctx, head); err != nil {
+				return fmt.Errorf("error pre-registering head %s: %w", head.Cid, err)
+			}
+		}
+	}
+
 	var session sync.WaitGroup
 	err := store.sendNewJobs(ctx, &session, dg, head, []cid.Cid{c})
 	session.Wait()

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -1723,7 +1723,7 @@ func (h *holdingDAGSvc) GetMany(ctx context.Context, cids []cid.Cid) <-chan *ipl
 	return out
 }
 
-// TestPartialSyncCleanCloseRecovery exercises a 2-peer scenario where peer0
+// TestCRDTPartialSyncCleanCloseRecovery exercises a 2-peer scenario where peer0
 // publishes three blocks and peer1 misses the middle one. peer0 is configured
 // with BroadcastBatchDelay so that the 2nd and 3rd Puts are folded into a
 // single broadcast advertising block 3 as the head (block 2 never appears in
@@ -1732,7 +1732,7 @@ func (h *holdingDAGSvc) GetMany(ctx context.Context, cids []cid.Cid) <-chan *ipl
 // that state, then reopened with the hold released. The test then waits
 // through two rebroadcast intervals to see whether rebroadcasts alone drive
 // peer1 to recover the missing block.
-func TestPartialSyncCleanCloseRecovery(t *testing.T) {
+func TestCRDTPartialSyncCleanCloseRecovery(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
 
@@ -1821,17 +1821,23 @@ func TestPartialSyncCleanCloseRecovery(t *testing.T) {
 		if p2 {
 			t.Fatal("peer1 should not have processed block 2 while it is held")
 		}
-		// peer1's head must still be block1: block3 is processed but not
-		// promoted to head because its child block2 is queued for processing
-		// (queuedChildren.Visit returns true on first visit), so processNode
-		// takes the "keep walking down" branch instead of adding block3 as a
-		// head. The head only advances once block2 is processed.
+		// peer1 should have block3 registered as a candidate head before
+		// walking the branch (so a partial walk is recoverable). block1
+		// may still be present because the heads.Replace at the bottom of
+		// the walk only fires once block2 is processed.
 		h1Mid, _, err := peer1.heads.List(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(h1Mid) != 1 || !h1Mid[0].Cid.Equals(block1) {
-			t.Fatalf("peer1 head should still be block1 (%s) while block2 is held, got %v", block1, h1Mid)
+		hasBlock3 := false
+		for _, h := range h1Mid {
+			if h.Cid.Equals(block3) {
+				hasBlock3 = true
+				break
+			}
+		}
+		if !hasBlock3 {
+			t.Fatalf("peer1 should have pre-registered block3 (%s) as a head before walking, got %v", block3, h1Mid)
 		}
 
 		// Clean close while block 2 is still held. ctx cancellation

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	blockstore "github.com/ipfs/boxo/blockstore"
@@ -1652,4 +1653,217 @@ func TestPurgeDAGCleanStore(t *testing.T) {
 	if len(remaining) != 1 {
 		t.Errorf("expected exactly 1 key (version) remaining, got %d: %v", len(remaining), remaining)
 	}
+}
+
+// holdingDAGSvc wraps an ipld.DAGService and blocks fetches of any CID for
+// which hold() has been called. The fetch unblocks when release() is called
+// or when the fetch context is cancelled. Used to simulate a peer that has
+// not yet received a specific block.
+type holdingDAGSvc struct {
+	ipld.DAGService
+	mu    sync.Mutex
+	holds map[cid.Cid]chan struct{}
+}
+
+func (h *holdingDAGSvc) hold(c cid.Cid) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.holds == nil {
+		h.holds = make(map[cid.Cid]chan struct{})
+	}
+	h.holds[c] = make(chan struct{})
+}
+
+func (h *holdingDAGSvc) release(c cid.Cid) {
+	h.mu.Lock()
+	ch, ok := h.holds[c]
+	delete(h.holds, c)
+	h.mu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (h *holdingDAGSvc) wait(ctx context.Context, c cid.Cid) error {
+	h.mu.Lock()
+	ch, ok := h.holds[c]
+	h.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (h *holdingDAGSvc) Get(ctx context.Context, c cid.Cid) (ipld.Node, error) {
+	if err := h.wait(ctx, c); err != nil {
+		return nil, err
+	}
+	return h.DAGService.Get(ctx, c)
+}
+
+func (h *holdingDAGSvc) GetMany(ctx context.Context, cids []cid.Cid) <-chan *ipld.NodeOption {
+	out := make(chan *ipld.NodeOption, len(cids))
+	go func() {
+		defer close(out)
+		for _, c := range cids {
+			if err := h.wait(ctx, c); err != nil {
+				out <- &ipld.NodeOption{Err: err}
+				return
+			}
+		}
+		for opt := range h.DAGService.GetMany(ctx, cids) {
+			out <- opt
+		}
+	}()
+	return out
+}
+
+// TestPartialSyncCleanCloseRecovery exercises a 2-peer scenario where peer0
+// publishes three blocks and peer1 misses the middle one. peer0 is configured
+// with BroadcastBatchDelay so that the 2nd and 3rd Puts are folded into a
+// single broadcast advertising block 3 as the head (block 2 never appears in
+// a broadcast). peer1 receives the broadcast, fetches and processes block 3,
+// and then blocks fetching its parent (block 2). peer1 is closed cleanly in
+// that state, then reopened with the hold released. The test then waits
+// through two rebroadcast intervals to see whether rebroadcasts alone drive
+// peer1 to recover the missing block.
+func TestPartialSyncCleanCloseRecovery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		bs := mdutils.Bserv()
+		dagserv := merkledag.NewDAGService(bs)
+
+		bcasts, cancelBcasts := newBroadcasters(t, 2)
+		t.Cleanup(cancelBcasts)
+
+		const (
+			batchDelay          = time.Second
+			rebroadcastInterval = time.Minute
+		)
+
+		mkOpts := func(name string, batch time.Duration) *Options {
+			o := DefaultOptions()
+			o.Logger = &testLogger{name: name + ": ", l: DefaultOptions().Logger}
+			o.RebroadcastInterval = rebroadcastInterval
+			o.RepairInterval = time.Hour
+			o.BroadcastBatchDelay = batch
+			o.NumWorkers = 1
+			o.DAGSyncerTimeout = time.Hour
+			return o
+		}
+
+		mapDs0 := dssync.MutexWrap(ds.NewMapDatastore())
+		peer0, err := New(mapDs0, ds.NewKey("crdttest"), dagserv, bcasts[0], mkOpts("p0", batchDelay))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = peer0.Close() })
+
+		holder := &holdingDAGSvc{DAGService: dagserv}
+		mapDs1 := dssync.MutexWrap(ds.NewMapDatastore())
+		peer1, err := New(mapDs1, ds.NewKey("crdttest"), holder, bcasts[1], mkOpts("p1", 0))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Phase 1: peer0 writes block 1; peer1 syncs it.
+		if err := peer0.Put(ctx, ds.NewKey("/k1"), []byte("v1")); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(batchDelay)
+		synctest.Wait()
+		h0, _, _ := peer0.heads.List(ctx)
+		h1, _, _ := peer1.heads.List(ctx)
+		if len(h0) != 1 || len(h1) != 1 || !h0[0].Cid.Equals(h1[0].Cid) {
+			t.Fatalf("peer1 should share peer0's head: p0=%v p1=%v", h0, h1)
+		}
+		block1 := h0[0].Cid
+
+		// Phase 2: hold block 2, then publish k2 and k3 back-to-back so they
+		// batch into a single broadcast advertising block 3 as the only head.
+		if err := peer0.Put(ctx, ds.NewKey("/k2"), []byte("v2")); err != nil {
+			t.Fatal(err)
+		}
+		h0, _, _ = peer0.heads.List(ctx)
+		block2 := h0[0].Cid
+		if block2.Equals(block1) {
+			t.Fatal("peer0 head should have advanced past block 1")
+		}
+		holder.hold(block2)
+		if err := peer0.Put(ctx, ds.NewKey("/k3"), []byte("v3")); err != nil {
+			t.Fatal(err)
+		}
+		h0, _, _ = peer0.heads.List(ctx)
+		block3 := h0[0].Cid
+
+		// Let the batch timer fire once. peer1 receives [block3], processes
+		// block 3, then blocks fetching block 2 on holder.
+		time.Sleep(batchDelay)
+		synctest.Wait()
+
+		p3, err := peer1.isProcessed(ctx, block3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !p3 {
+			t.Fatal("peer1 should have processed block 3")
+		}
+		p2, err := peer1.isProcessed(ctx, block2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if p2 {
+			t.Fatal("peer1 should not have processed block 2 while it is held")
+		}
+		// peer1's head must still be block1: block3 is processed but not
+		// promoted to head because its child block2 is queued for processing
+		// (queuedChildren.Visit returns true on first visit), so processNode
+		// takes the "keep walking down" branch instead of adding block3 as a
+		// head. The head only advances once block2 is processed.
+		h1Mid, _, err := peer1.heads.List(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(h1Mid) != 1 || !h1Mid[0].Cid.Equals(block1) {
+			t.Fatalf("peer1 head should still be block1 (%s) while block2 is held, got %v", block1, h1Mid)
+		}
+
+		// Clean close while block 2 is still held. ctx cancellation
+		// propagates into holder.wait, so the in-flight fetch returns
+		// without waiting on any external error.
+		if err := peer1.Close(); err != nil {
+			t.Fatal(err)
+		}
+		synctest.Wait()
+
+		// Reopen peer1 with block 2 released, and wait through two
+		// rebroadcast intervals to see whether rebroadcasts alone recover
+		// the missing block.
+		holder.release(block2)
+		peer1b, err := New(mapDs1, ds.NewKey("crdttest"), holder, bcasts[1], mkOpts("p1b", 0))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = peer1b.Close() })
+
+		time.Sleep(3 * rebroadcastInterval)
+		synctest.Wait()
+
+		p2After, _ := peer1b.isProcessed(ctx, block2)
+		p3After, _ := peer1b.isProcessed(ctx, block3)
+		hAfter, _, _ := peer1b.heads.List(ctx)
+		dirtyAfter := peer1b.IsDirty(ctx)
+
+		if p2After && len(hAfter) == 1 && hAfter[0].Cid.Equals(block3) && !dirtyAfter {
+			return
+		}
+		t.Fatalf("peer1 did not recover after 3 rebroadcasts: block2.processed=%v block3.processed=%v heads=%v dirty=%v (want head=%s, block2 processed, dirty=false)",
+			p2After, p3After, hAfter, dirtyAfter, block3)
+	})
 }

--- a/crdt_test.go
+++ b/crdt_test.go
@@ -1729,9 +1729,12 @@ func (h *holdingDAGSvc) GetMany(ctx context.Context, cids []cid.Cid) <-chan *ipl
 // single broadcast advertising block 3 as the head (block 2 never appears in
 // a broadcast). peer1 receives the broadcast, fetches and processes block 3,
 // and then blocks fetching its parent (block 2). peer1 is closed cleanly in
-// that state, then reopened with the hold released. The test then waits
-// through two rebroadcast intervals to see whether rebroadcasts alone drive
-// peer1 to recover the missing block.
+// that state, then reopened with the hold released. The test then asserts
+// that peer1 recovers the missing block: handleBranch pre-registers block 3
+// as a head before walking, so the partial walk leaves a recoverable trace;
+// the worker marks the store dirty when its in-flight fetch is cancelled by
+// Close; on reopen the repair loop fires immediately, walks down from the
+// pre-registered head 3, finds block 2 unprocessed, and reprocesses it.
 func TestCRDTPartialSyncCleanCloseRecovery(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
@@ -1848,9 +1851,7 @@ func TestCRDTPartialSyncCleanCloseRecovery(t *testing.T) {
 		}
 		synctest.Wait()
 
-		// Reopen peer1 with block 2 released, and wait through two
-		// rebroadcast intervals to see whether rebroadcasts alone recover
-		// the missing block.
+		// Reopen peer1 with block 2 released, and wait for DAG to be repaired.
 		holder.release(block2)
 		peer1b, err := New(mapDs1, ds.NewKey("crdttest"), holder, bcasts[1], mkOpts("p1b", 0))
 		if err != nil {
@@ -1858,18 +1859,23 @@ func TestCRDTPartialSyncCleanCloseRecovery(t *testing.T) {
 		}
 		t.Cleanup(func() { _ = peer1b.Close() })
 
-		time.Sleep(3 * rebroadcastInterval)
 		synctest.Wait()
 
-		p2After, _ := peer1b.isProcessed(ctx, block2)
 		p3After, _ := peer1b.isProcessed(ctx, block3)
-		hAfter, _, _ := peer1b.heads.List(ctx)
-		dirtyAfter := peer1b.IsDirty(ctx)
-
-		if p2After && len(hAfter) == 1 && hAfter[0].Cid.Equals(block3) && !dirtyAfter {
-			return
+		if !p3After {
+			t.Fatal("peer1 should have processed block 3 after release and reopen")
 		}
-		t.Fatalf("peer1 did not recover after 3 rebroadcasts: block2.processed=%v block3.processed=%v heads=%v dirty=%v (want head=%s, block2 processed, dirty=false)",
-			p2After, p3After, hAfter, dirtyAfter, block3)
+		p2After, _ := peer1b.isProcessed(ctx, block2)
+		if !p2After {
+			t.Fatal("peer1 should have processed block 2 after release and reopen")
+		}
+		hAfter, _, _ := peer1b.heads.List(ctx)
+		if len(hAfter) != 1 || !hAfter[0].Cid.Equals(block3) {
+			t.Fatalf("peer1 should have block3 as head after recovery, got %v", hAfter)
+		}
+		dirtyAfter := peer1b.IsDirty(ctx)
+		if dirtyAfter {
+			t.Fatal("peer1 should be marked clean after successful recovery")
+		}
 	})
 }


### PR DESCRIPTION
Fixes #279

Alternative to #350

## Problem

When `handleBranch()` walks a newly-received branch, the new head is only promoted to the heads set at the very bottom of the walk. If the process crashes or is closed cleanly mid-walk, the new head is never persisted. Because the merged-but-unfinished branch is still marked as processed, `repairDAG()` (which walks down from the heads set) has no entry point to reach the missing portion, and the peer ends up stuck with an incomplete DAG that rebroadcasts alone cannot recover.

## Fix

Pre-register the branch tip as a head in `handleBranch()` before walking down. A partial walk now leaves a recoverable trace. A clean close during a branch walk calls `MarkDirty()` trigggering `repairDAG()` on restart. `repairDAG()` finds the pre-registered head and re-walks the branch to fill in the unprocessed nodes. The pre-registration is skipped when `head.Cid != c` (called from `repairDAG()` mid-branch) and when the CID is already a head (idempotent fast path).

#351 is complementary and ensures that if the node crashes during a branch walk, the store is marked dirty on restart and the branch can be walked again during `repairDAG()`

## Test

Added `TestCRDTPartialSyncCleanCloseRecovery` regression test that reproduces the problem

https://github.com/ipfs/go-ds-crdt/blob/371bed6c1cc287db2c2f4668263116fe74b97492/crdt_test.go#L1726-L1738